### PR TITLE
added unused create_tables function to lifespan_factory

### DIFF
--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -104,6 +104,9 @@ def lifespan_factory(
             if isinstance(settings, RedisRateLimiterSettings):
                 await create_redis_rate_limit_pool()
 
+            if create_tables_on_start:
+                await create_tables()
+
             initialization_complete.set()
 
             yield


### PR DESCRIPTION
The create tables function was not used and it seems that it fixes problems explained in Issue#168