### PR TITLE
Tied the version of Python to 3.11 to fix Greenlet compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{ include = "src" }]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "~3.11"
 python-dotenv = "^1.0.0"
 pydantic = { extras = ["email"], version = "^2.6.1" }
 fastapi = "^0.109.1"


### PR DESCRIPTION
Greenlet isn't compatible with 3.12 onwards, and so whenever I ran poetry install I would get a compatibility issue, as it would try to use Python 3.12, which wasn't compatible. This change ensures that only the most recent version of Python 3.11 is used instead. Patch releases etc of 3.11 will still be permitted with this syntax