### PR TITLE
bugfix: ensure user lookup returns model instance in write_post endpoint

### DIFF
--- a/src/app/api/v1/posts.py
+++ b/src/app/api/v1/posts.py
@@ -24,7 +24,8 @@ async def write_post(
     current_user: Annotated[dict, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)],
 ) -> PostRead:
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False, schema_to_select=UserRead)
+    db_user = await crud_users.get(db=db, username=username, is_deleted=False, schema_to_select=UserRead,
+                                   return_as_model=True)
     if db_user is None:
         raise NotFoundException("User not found")
 


### PR DESCRIPTION
# Overview
Hello, this is my first pull request.
I encountered the same issue as #183 while testing the project, so this pull request is to fix #183.
# Issue Details
I sent the following request:
```shell
curl --location --request POST 'http://127.0.0.1:8000/api/v1/admin/post' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <TOKEN>' \
--data-raw '{
    "title": "This is my post",
    "text": "This is the content of my post.",
    "media_url": "https://www.postimageurl.com"
}'
```
The API returned HTTP 500 Internal Server Error.
<details>
<summary>Error stack trace information</summary>

```
INFO:     127.0.0.1:62626 - "POST /api/v1/admin/post HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\base.py", line 186, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\uvicorn\protocols\http\httptools_impl.py", line 409, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\uvicorn\middleware\proxy_headers.py", line 60, in __call__
    |     return await self.app(scope, receive, send)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\fastapi\applications.py", line 1054, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\applications.py", line 113, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\errors.py", line 187, in __call__
    |     raise exc
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\errors.py", line 165, in __call__
    |     await self.app(scope, receive, _send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\base.py", line 185, in __call__
    |     with collapse_excgroups():
    |          ^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\BlackYau\AppData\Roaming\uv\python\cpython-3.12.10-windows-x86_64-none\Lib\contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\base.py", line 187, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\src\app\middleware\client_cache_middleware.py", line 54, in dispatch
    |     response: Response = await call_next(request)
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\base.py", line 163, in call_next
    |     raise app_exc
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\base.py", line 149, in coro
    |     await self.app(scope, receive_or_disconnect, send_no_error)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\middleware\exceptions.py", line 62, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\_exception_handler.py", line 62, in wrapped_app
    |     raise exc
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\_exception_handler.py", line 51, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\routing.py", line 715, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\routing.py", line 735, in app
    |     await route.handle(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\routing.py", line 288, in handle
    |     await self.app(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\routing.py", line 76, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\_exception_handler.py", line 62, in wrapped_app
    |     raise exc
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\_exception_handler.py", line 51, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\starlette\routing.py", line 73, in app
    |     response = await f(request)
    |                ^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\fastapi\routing.py", line 301, in app
    |     raw_response = await run_endpoint_function(
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\.venv\Lib\site-packages\fastapi\routing.py", line 212, in run_endpoint_function
    |     return await dependant.call(**values)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\VSCodeProject\tiktok_collect_server_v2\src\app\api\v1\posts.py", line 35, in write_post
    |     if current_user["id"] != db_user.id:
    |                              ^^^^^^^^^^
    | AttributeError: 'dict' object has no attribute 'id'
    +------------------------------------
```

</details>

# Testing

After fixing it, I sent the same request and got the normal return information.

API returns HTTP 201

```
{
    "id": 3,
    "title": "This is my post",
    "text": "This is the content of my post.",
    "media_url": "https://www.postimageurl.com",
    "created_by_user_id": 1,
    "created_at": "2025-08-12T16:02:08.509550Z"
}
```

Console log:

```
INFO:     127.0.0.1:62839 - "POST /api/v1/admin/post HTTP/1.1" 201 Created
```

Query the existence of newly created posts through the API interface

```shell
curl --location --request GET 'http://127.0.0.1:8000/api/v1/admin/posts?page=1&items_per_page=10' \
--header 'Authorization: Bearer <TOKEN>'
```

```json
{
    "data": [
        {
            "id": 3,
            "title": "This is my post",
            "text": "This is the content of my post.",
            "media_url": "https://www.postimageurl.com",
            "created_by_user_id": 1,
            "created_at": "2025-08-12T16:02:08.509550Z"
        }
    ],
    "total_count": 1,
    "has_more": false,
    "page": 1,
    "items_per_page": 10
}
```

I think I've solved #183.
