### PR TITLE
Remove unused Redis SSL setting from admin init

### DIFF
--- a/src/app/admin/initialize.py
+++ b/src/app/admin/initialize.py
@@ -22,7 +22,6 @@ def create_admin_interface() -> Optional[CRUDAdmin]:
             "port": settings.CRUD_ADMIN_REDIS_PORT,
             "db": settings.CRUD_ADMIN_REDIS_DB,
             "password": settings.CRUD_ADMIN_REDIS_PASSWORD if settings.CRUD_ADMIN_REDIS_PASSWORD != "None" else None,
-            "ssl": settings.CRUD_ADMIN_REDIS_SSL,
         }
 
     admin = CRUDAdmin(


### PR DESCRIPTION
alfter config CRUD_ADMIN_REDIS_SSL, will fail 

```
  File "/Users/lidashuang/Projects/nocode/vision-rest/src/app/main.py", line 24, in <module>
    admin = create_admin_interface()
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lidashuang/Projects/nocode/vision-rest/src/app/admin/initialize.py", line 31, in create_admin_interface
    admin = CRUDAdmin(
            ^^^^^^^^^^
  File "/Users/lidashuang/Projects/nocode/vision-rest/.venv/lib/python3.11/site-packages/crudadmin/admin_interface/crud_admin.py", line 465, in __init__
    self._session_backend_kwargs = self._configure_session_backend(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lidashuang/Projects/nocode/vision-rest/.venv/lib/python3.11/site-packages/crudadmin/admin_interface/crud_admin.py", line 1343, in _configure_session_backend
    redis_config_obj = RedisConfig(**redis_config)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lidashuang/Projects/nocode/vision-rest/.venv/lib/python3.11/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for RedisConfig
ssl
  Extra inputs are not permitted [type=extra_forbidden, input_value=False, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden

```