### PR TITLE
Fix TokenBlacklist naming convention to TokenBlackList

### DIFF
--- a/docs/user-guide/authentication/jwt-tokens.md
+++ b/docs/user-guide/authentication/jwt-tokens.md
@@ -315,7 +315,7 @@ The system uses a database table to track invalidated tokens:
 
 ```python
 # models/token_blacklist.py
-class TokenBlacklist(Base):
+class TokenBlackList(Base):
     __tablename__ = "token_blacklist"
     
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -360,7 +360,7 @@ async def blacklist_token(token: str, db: AsyncSession) -> None:
         # 3. Store in blacklist with expiration
         await crud_token_blacklist.create(
             db, 
-            object=TokenBlacklistCreate(token=token, expires_at=expires_at)
+            object=TokenBlackListCreate(token=token, expires_at=expires_at)
         )
 ```
 

--- a/src/app/core/db/crud_token_blacklist.py
+++ b/src/app/core/db/crud_token_blacklist.py
@@ -1,14 +1,14 @@
 from fastcrud import FastCRUD
 
-from ..db.token_blacklist import TokenBlacklist
-from ..schemas import TokenBlacklistCreate, TokenBlacklistRead, TokenBlacklistUpdate
+from ..db.token_blacklist import TokenBlackList
+from ..schemas import TokenBlackListCreate, TokenBlackListRead, TokenBlackListUpdate
 
-CRUDTokenBlacklist = FastCRUD[
-    TokenBlacklist,
-    TokenBlacklistCreate,
-    TokenBlacklistUpdate,
-    TokenBlacklistUpdate,
-    TokenBlacklistUpdate,
-    TokenBlacklistRead,
+CRUDTokenBlackList = FastCRUD[
+    TokenBlackList,
+    TokenBlackListCreate,
+    TokenBlackListUpdate,
+    TokenBlackListUpdate,
+    TokenBlackListUpdate,
+    TokenBlackListRead,
 ]
-crud_token_blacklist = CRUDTokenBlacklist(TokenBlacklist)
+crud_token_blacklist = CRUDTokenBlackList(TokenBlackList)

--- a/src/app/core/db/token_blacklist.py
+++ b/src/app/core/db/token_blacklist.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from .database import Base
 
 
-class TokenBlacklist(Base):
+class TokenBlackList(Base):
     __tablename__ = "token_blacklist"
 
     id: Mapped[int] = mapped_column("id", autoincrement=True, nullable=False, unique=True, primary_key=True, init=False)

--- a/src/app/core/schemas.py
+++ b/src/app/core/schemas.py
@@ -58,18 +58,18 @@ class TokenData(BaseModel):
     username_or_email: str
 
 
-class TokenBlacklistBase(BaseModel):
+class TokenBlackListBase(BaseModel):
     token: str
     expires_at: datetime
 
 
-class TokenBlacklistRead(TokenBlacklistBase):
+class TokenBlackListRead(TokenBlackListBase):
     id: int
 
 
-class TokenBlacklistCreate(TokenBlacklistBase):
+class TokenBlackListCreate(TokenBlackListBase):
     pass
 
 
-class TokenBlacklistUpdate(TokenBlacklistBase):
+class TokenBlackListUpdate(TokenBlackListBase):
     pass

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..crud.crud_users import crud_users
 from .config import settings
 from .db.crud_token_blacklist import crud_token_blacklist
-from .schemas import TokenBlacklistCreate, TokenData
+from .schemas import TokenBlackListCreate, TokenData
 
 SECRET_KEY: SecretStr = settings.SECRET_KEY
 ALGORITHM = settings.ALGORITHM
@@ -126,7 +126,7 @@ async def blacklist_tokens(access_token: str, refresh_token: str, db: AsyncSessi
         exp_timestamp = payload.get("exp")
         if exp_timestamp is not None:
             expires_at = datetime.fromtimestamp(exp_timestamp)
-            await crud_token_blacklist.create(db, object=TokenBlacklistCreate(token=token, expires_at=expires_at))
+            await crud_token_blacklist.create(db, object=TokenBlackListCreate(token=token, expires_at=expires_at))
 
 
 async def blacklist_token(token: str, db: AsyncSession) -> None:
@@ -134,4 +134,4 @@ async def blacklist_token(token: str, db: AsyncSession) -> None:
     exp_timestamp = payload.get("exp")
     if exp_timestamp is not None:
         expires_at = datetime.fromtimestamp(exp_timestamp)
-        await crud_token_blacklist.create(db, object=TokenBlacklistCreate(token=token, expires_at=expires_at))
+        await crud_token_blacklist.create(db, object=TokenBlackListCreate(token=token, expires_at=expires_at))


### PR DESCRIPTION
- Updated class name from TokenBlacklist to TokenBlackList for proper PascalCase
- Fixed all related schema classes (TokenBlackListBase, TokenBlackListRead, etc.)
- Updated imports and references throughout codebase
- Updated documentation to reflect naming changes
- Maintains consistency with existing naming patterns like RateLimit

This follows Python PascalCase conventions where each word component is capitalized.