### PR TITLE
fix: refuse empty admin credentials and compare them in constant time

### DIFF
--- a/backend/src/infrastructure/security/production_validator.py
+++ b/backend/src/infrastructure/security/production_validator.py
@@ -200,6 +200,13 @@ class ProductionSecurityValidator:
                 "Set a strong password for production."
             )
 
+        if self.settings.ADMIN_ENABLED and (not self.settings.ADMIN_USERNAME or not self.settings.ADMIN_PASSWORD):
+            errors.append(
+                "Admin interface is enabled (ADMIN_ENABLED=true) but ADMIN_USERNAME and/or "
+                "ADMIN_PASSWORD are not set. Set both to strong, unique values or set "
+                "ADMIN_ENABLED=false for production."
+            )
+
         return errors
 
     def _validate_warning_security(self) -> None:

--- a/backend/src/interfaces/admin/auth.py
+++ b/backend/src/interfaces/admin/auth.py
@@ -1,5 +1,7 @@
 """Authentication backend for SQLAdmin."""
 
+import hmac
+
 from sqladmin.authentication import AuthenticationBackend
 from starlette.requests import Request
 
@@ -17,7 +19,15 @@ class AdminAuth(AuthenticationBackend):
 
         settings = get_settings()
 
-        if username == settings.ADMIN_USERNAME and password == settings.ADMIN_PASSWORD:
+        if not settings.ADMIN_USERNAME or not settings.ADMIN_PASSWORD:
+            return False
+
+        username = str(username or "")
+        password = str(password or "")
+
+        if hmac.compare_digest(username, settings.ADMIN_USERNAME) and hmac.compare_digest(
+            password, settings.ADMIN_PASSWORD
+        ):
             request.session.update({"admin_authenticated": True})
             return True
 

--- a/backend/src/interfaces/admin/auth.py
+++ b/backend/src/interfaces/admin/auth.py
@@ -8,26 +8,28 @@ from starlette.requests import Request
 from ...infrastructure.config.settings import get_settings
 
 
+def _credential_matches(submitted: object, expected: str) -> bool:
+    """Compare a submitted credential against the configured one in constant time."""
+    if not isinstance(submitted, str):
+        return False
+    return hmac.compare_digest(submitted.encode(), expected.encode())
+
+
 class AdminAuth(AuthenticationBackend):
     """Session-based authentication for the admin interface."""
 
     async def login(self, request: Request) -> bool:
         """Validate login credentials and create session."""
         form = await request.form()
-        username = form.get("username")
-        password = form.get("password")
-
         settings = get_settings()
 
         if not settings.ADMIN_USERNAME or not settings.ADMIN_PASSWORD:
             return False
 
-        username = str(username or "")
-        password = str(password or "")
+        username_matches = _credential_matches(form.get("username"), settings.ADMIN_USERNAME)
+        password_matches = _credential_matches(form.get("password"), settings.ADMIN_PASSWORD)
 
-        if hmac.compare_digest(username, settings.ADMIN_USERNAME) and hmac.compare_digest(
-            password, settings.ADMIN_PASSWORD
-        ):
+        if username_matches and password_matches:
             request.session.update({"admin_authenticated": True})
             return True
 

--- a/backend/tests/unit/infrastructure/security/test_production_validator.py
+++ b/backend/tests/unit/infrastructure/security/test_production_validator.py
@@ -324,17 +324,16 @@ class TestProductionSecurityValidator:
         with pytest.raises(ProductionSecurityError):
             validate_production_security(settings)
 
-    def test_no_admin_credentials_skips_admin_checks(self, caplog):
-        """Test that missing admin credentials skip admin checks."""
+    def test_empty_admin_credentials_raises_error(self):
+        """Test that an enabled admin interface without credentials is a critical issue."""
         settings = self.create_mock_settings(ADMIN_USERNAME="", ADMIN_PASSWORD="")
         validator = ProductionSecurityValidator(settings)
 
-        validator.validate_production_security()
+        with pytest.raises(ProductionSecurityError) as exc_info:
+            validator.validate_production_security()
 
-        # Should not have admin credential warnings
-        warning_logs = [record for record in caplog.records if record.levelname == "WARNING"]
-        admin_warnings = [log for log in warning_logs if "Admin username" in log.message or "Admin password" in log.message]
-        assert len(admin_warnings) == 0
+        assert "ADMIN_USERNAME" in str(exc_info.value)
+        assert "ADMIN_PASSWORD" in str(exc_info.value)
 
     def test_redis_ssl_with_external_host(self, caplog):
         """Test that external Redis without SSL logs warning."""

--- a/backend/tests/unit/interfaces/admin/test_auth.py
+++ b/backend/tests/unit/interfaces/admin/test_auth.py
@@ -1,0 +1,79 @@
+"""Tests for the SQLAdmin authentication backend."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.interfaces.admin.auth import AdminAuth
+
+
+class FakeRequest:
+    def __init__(self, form: dict[str, Any]) -> None:
+        self._form = form
+        self.session: dict[str, Any] = {}
+
+    async def form(self) -> dict[str, Any]:
+        return self._form
+
+
+async def _login(configured: tuple[str, str], form: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    username, password = configured
+    request = FakeRequest(form)
+    settings = SimpleNamespace(ADMIN_USERNAME=username, ADMIN_PASSWORD=password)
+    with patch("src.interfaces.admin.auth.get_settings", return_value=settings):
+        authenticated = await AdminAuth(secret_key="test").login(request)
+    return authenticated, request.session
+
+
+@pytest.mark.parametrize(
+    ("configured", "form"),
+    [
+        (("", ""), {"username": "", "password": ""}),
+        (("admin", ""), {"username": "admin", "password": ""}),
+        (("", "s3cret"), {"username": "", "password": "s3cret"}),
+    ],
+)
+async def test_login_is_disabled_until_both_credentials_are_configured(configured, form):
+    authenticated, session = await _login(configured, form)
+
+    assert authenticated is False
+    assert session == {}
+
+
+async def test_login_with_configured_credentials_starts_admin_session():
+    authenticated, session = await _login(("admin", "s3cret"), {"username": "admin", "password": "s3cret"})
+
+    assert authenticated is True
+    assert session == {"admin_authenticated": True}
+
+
+@pytest.mark.parametrize(
+    "form",
+    [
+        {"username": "admin", "password": "wrong"},
+        {"username": "wrong", "password": "s3cret"},
+        {"username": "admin"},
+        {},
+    ],
+)
+async def test_login_rejects_wrong_or_missing_credentials(form):
+    authenticated, session = await _login(("admin", "s3cret"), form)
+
+    assert authenticated is False
+    assert session == {}
+
+
+async def test_login_rejects_non_ascii_input_without_raising():
+    authenticated, session = await _login(("admin", "s3cret"), {"username": "admín", "password": "s3cret"})
+
+    assert authenticated is False
+    assert session == {}
+
+
+async def test_login_accepts_non_ascii_configured_password():
+    authenticated, session = await _login(("admin", "contraseña"), {"username": "admin", "password": "contraseña"})
+
+    assert authenticated is True
+    assert session == {"admin_authenticated": True}

--- a/docs/user-guide/admin-panel/configuration.md
+++ b/docs/user-guide/admin-panel/configuration.md
@@ -8,7 +8,7 @@ The admin panel has a deliberately small surface area: it's a [SQLAdmin](https:/
 # Toggle the admin panel (default: true)
 ADMIN_ENABLED=true
 
-# Admin login credentials
+# Admin login credentials — must BOTH be set, otherwise login always fails
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=your-secure-password
 
@@ -46,15 +46,16 @@ class AdminAuth(AuthenticationBackend):
         password = form.get("password")
 
         settings = get_settings()
-        if username == settings.ADMIN_USERNAME and password == settings.ADMIN_PASSWORD:
-            request.session.update({"admin_authenticated": True})
-            return True
-        return False
+        if not settings.ADMIN_USERNAME or not settings.ADMIN_PASSWORD:
+            return False
+        # constant-time comparison of username and password
+        ...
 ```
 
 Notes:
 
 - Credentials come from environment variables, **not the database**. Restart the app to change them.
+- **Admin login is disabled until both `ADMIN_USERNAME` and `ADMIN_PASSWORD` are set.** With the empty defaults, every login attempt fails — an empty form submission does not authenticate.
 - Only one admin login is supported. There's no multi-admin user table.
 - The session is encrypted with `SECRET_KEY` via Starlette's `SessionMiddleware`.
 - Logout clears the session: `request.session.clear()`.
@@ -134,9 +135,9 @@ Three options, ordered by aggressiveness:
     If you can't restrict at the network layer, treat `ADMIN_PASSWORD` like a production secret:
     - Pull from a secrets manager at deploy time, never commit
     - Rotate periodically
-    - Use a long, high-entropy password (the production security validator will refuse to start the app if `SECRET_KEY` is the placeholder, but it doesn't validate `ADMIN_PASSWORD`)
+    - Use a long, high-entropy password (the production security validator refuses to start the app if `SECRET_KEY` is the placeholder, or if the admin panel is enabled with empty credentials; weak admin passwords are logged as warnings)
 
-The Production Security Validator (`infrastructure/security/`) checks several things at startup when `ENVIRONMENT=production`, but admin credentials aren't currently in the validation list. Be deliberate about what you set.
+The Production Security Validator (`infrastructure/security/`) checks several things at startup when `ENVIRONMENT=production`, including that `ADMIN_USERNAME`/`ADMIN_PASSWORD` are set whenever `ADMIN_ENABLED=true`. Be deliberate about what you set.
 
 ## Environment Detection
 

--- a/docs/user-guide/admin-panel/index.md
+++ b/docs/user-guide/admin-panel/index.md
@@ -23,6 +23,9 @@ SECRET_KEY=<used for admin session encryption>
 
 Visit <http://localhost:8000/admin>, enter those credentials, and you're in.
 
+!!! warning "Login is disabled until credentials are configured"
+    `ADMIN_USERNAME` and `ADMIN_PASSWORD` default to empty. With either unset, **every admin login attempt fails** — an empty form submission does not authenticate. Set both before the panel is usable.
+
 ## What You'll Learn
 
 - **[Configuration](configuration.md)** - Environment variables and deployment settings


### PR DESCRIPTION
The SQLAdmin login compared the submitted credentials against ADMIN_USERNAME and ADMIN_PASSWORD with a plain == check. Both settings default to an empty string while ADMIN_ENABLED defaults to true, so submitting the login form with empty fields authenticated anyone on a default deployment. The production validator also skipped its admin checks entirely when the credentials were empty.

This PR:

- refuses authentication in AdminAuth.login when either credential is not configured;
- compares both credentials with hmac.compare_digest;
- makes the production validator raise a critical error when ADMIN_ENABLED is true but the admin credentials are unset (previously it returned early and skipped the check).

Docs updated to state that admin login stays disabled until both credentials are set. Unit tests updated and passing.

Written by Kimi, Authored by @emiliano-go
