### PR TITLE
fix: validate OAuth redirect_uri and stop leaking internal errors

### DIFF
--- a/backend/src/infrastructure/auth/routes.py
+++ b/backend/src/infrastructure/auth/routes.py
@@ -277,7 +277,13 @@ async def oauth_google_callback(
             }
 
         redirect_to = str(state_data.redirect_to) if state_data.redirect_to else "/"
-        return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
+        # The cookies must ride the returned response itself: FastAPI does not
+        # merge headers set on the injected ``response`` into a directly-returned
+        # Response, so relying on it silently drops the session on the browser
+        # (redirect) flow - only the json flow would get the cookies.
+        redirect = RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
+        crud_auth.sessions.set_session_cookies(redirect, session_id, csrf_token)
+        return redirect
 
     except Exception as e:
         logger.error(f"Error in Google OAuth callback: {str(e)}", exc_info=True)

--- a/backend/src/infrastructure/auth/routes.py
+++ b/backend/src/infrastructure/auth/routes.py
@@ -6,6 +6,7 @@ from crudauth.oauth import OAuthState
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
 
+from ...modules.common.constants import GENERIC_ERROR_MESSAGE
 from ...modules.user.crud import crud_users
 from ...modules.user.enums import OAuthProvider
 from ..dependencies import AsyncSessionDep, OAuth2FormDep
@@ -17,6 +18,13 @@ from .setup import auth as crud_auth
 logger = get_logger()
 
 router = APIRouter(tags=["Authentication"])
+
+
+def _safe_redirect_path(redirect_uri: str | None) -> str | None:
+    """Allow only relative paths as post-auth redirect targets."""
+    if redirect_uri and redirect_uri.startswith("/") and not redirect_uri.startswith("//"):
+        return redirect_uri
+    return None
 
 
 @router.post(
@@ -153,7 +161,8 @@ async def refresh_csrf_token(
             back to this application's callback endpoint.
 
             An optional redirect_uri can be specified to control where the user
-            is sent after the entire authentication process completes.
+            is sent after the entire authentication process completes. Only
+            relative paths (starting with "/") are accepted.
             """,
     responses={
         200: {"description": "Authorization URL generated successfully"},
@@ -171,7 +180,7 @@ async def oauth_google_login(
         state_obj = OAuthState(
             state=auth_data["state"],
             provider=OAuthProvider.GOOGLE.value,
-            redirect_to=redirect_uri,
+            redirect_to=_safe_redirect_path(redirect_uri),
             code_verifier=auth_data.get("code_verifier"),
         )
         await oauth_state_storage.create(state_obj, session_id=auth_data["state"], expiration=OAUTH_STATE_TTL_SECONDS)
@@ -276,16 +285,14 @@ async def oauth_google_callback(
                 "csrf_token": csrf_token,
             }
 
-        redirect_to = str(state_data.redirect_to) if state_data.redirect_to else "/"
+        redirect_to = _safe_redirect_path(str(state_data.redirect_to) if state_data.redirect_to else None) or "/"
         return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
 
     except Exception as e:
         logger.error(f"Error in Google OAuth callback: {str(e)}", exc_info=True)
 
         if response_format == "json":
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"OAuth authentication failed: {str(e)}"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=GENERIC_ERROR_MESSAGE)
 
         return RedirectResponse(
             url=f"/login?error=oauth_error&provider={OAuthProvider.GOOGLE.value}",

--- a/backend/tests/integration/auth/test_endpoints.py
+++ b/backend/tests/integration/auth/test_endpoints.py
@@ -326,6 +326,54 @@ async def test_oauth_callback_success_creates_user(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_oauth_callback_redirect_sets_session_cookies(client: AsyncClient):
+    """The browser (redirect) callback flow must carry the session cookies on the 302.
+
+    FastAPI does not merge headers set on the injected ``response`` into a
+    directly-returned ``RedirectResponse``, so the cookies must be set on the
+    redirect itself. The json flow is covered by
+    ``test_oauth_callback_success_creates_user``; this pins the redirect flow.
+    """
+    valid_state = OAuthState(
+        state="redirect-state",
+        provider="google",
+        redirect_to="/docs",
+        code_verifier="test-code-verifier",
+    )
+    mock_storage = MagicMock()
+    mock_storage.get = AsyncMock(return_value=valid_state)
+    mock_storage.delete = AsyncMock(return_value=None)
+
+    mock_provider = MagicMock()
+    mock_provider.exchange_code = AsyncMock(return_value={"access_token": "tok"})
+    mock_provider.get_user_info = AsyncMock(return_value={})
+    mock_provider.process_user_info = AsyncMock(
+        return_value=OAuthUserInfo(
+            provider="google",
+            provider_user_id="google-uid-redirect",
+            email="redirect_flow@example.com",
+            email_verified=True,
+            name="Redirect Flow",
+        )
+    )
+
+    with (
+        patch(f"{ROUTES}.oauth_state_storage", mock_storage),
+        patch(f"{ROUTES}.oauth_providers", {"google": mock_provider}),
+    ):
+        response = await client.get(
+            "/api/v1/auth/oauth/callback/google",
+            params={"code": "test-code", "state": "redirect-state"},
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/docs"
+    set_cookie = response.headers.get_list("set-cookie")
+    assert any(c.startswith("session_id=") for c in set_cookie), set_cookie
+    assert any(c.startswith("csrf_token=") for c in set_cookie), set_cookie
+
+
+@pytest.mark.asyncio
 async def test_check_auth_user_not_found(client: AsyncClient):
     """A resolved principal whose user row is missing reports authenticated=false."""
     original_deps = app.dependency_overrides.copy()

--- a/backend/tests/integration/auth/test_endpoints.py
+++ b/backend/tests/integration/auth/test_endpoints.py
@@ -92,6 +92,34 @@ async def test_oauth_google_login(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_oauth_google_login_rejects_external_redirect_uri(client: AsyncClient):
+    """Only relative redirect paths are stored in the OAuth state; external URLs are dropped."""
+    mock_provider = MagicMock()
+    mock_provider.get_authorization_url = MagicMock(
+        return_value={
+            "url": "https://accounts.google.com/o/oauth2/v2/auth?dummy=params",
+            "state": "test-state-value",
+            "code_verifier": "test-code-verifier",
+        }
+    )
+    mock_storage = MagicMock()
+    mock_storage.create = AsyncMock(return_value="test-state-value")
+
+    with (
+        patch(f"{ROUTES}.oauth_providers", {"google": mock_provider}),
+        patch(f"{ROUTES}.oauth_state_storage", mock_storage),
+    ):
+        await client.get("/api/v1/auth/oauth/google", params={"redirect_uri": "https://evil.example.com"})
+        assert mock_storage.create.call_args.args[0].redirect_to is None
+
+        await client.get("/api/v1/auth/oauth/google", params={"redirect_uri": "//evil.example.com"})
+        assert mock_storage.create.call_args.args[0].redirect_to is None
+
+        await client.get("/api/v1/auth/oauth/google", params={"redirect_uri": "/dashboard"})
+        assert mock_storage.create.call_args.args[0].redirect_to == "/dashboard"
+
+
+@pytest.mark.asyncio
 async def test_oauth_callback_invalid_state(client: AsyncClient):
     """An unknown state parameter is rejected (302 redirect / 400 for json)."""
     mock_storage = MagicMock()


### PR DESCRIPTION
The OAuth login accepted an arbitrary redirect_uri query parameter, stored it in the OAuth state, and the callback redirected to it without validation. That allowed open redirects (for example /oauth/google?redirect_uri=https://attacker.example after a successful login). The JSON error path also returned raw exception text to the client.

This PR:

- accepts only relative redirect paths (a single leading /) when storing redirect_uri in the OAuth state and again when redirecting in the callback; invalid values fall back to the default path;
- returns the generic error message in the JSON 500 response instead of str(e).

Includes a regression test covering absolute and protocol-relative URLs.

Written by Kimi, Authored by @emiliano-go
