### PR TITLE
fix: gate staging and production docs behind superuser auth

### DIFF
--- a/backend/src/infrastructure/app_factory.py
+++ b/backend/src/infrastructure/app_factory.py
@@ -242,12 +242,27 @@ def create_application(
 
     kwargs.update(metadata)
 
+    show_docs = isinstance(settings, EnvironmentSettings) and (
+        settings.ENVIRONMENT != EnvironmentOption.PRODUCTION or _enable_docs_in_production
+    )
+
+    is_production = isinstance(settings, EnvironmentSettings) and settings.ENVIRONMENT == EnvironmentOption.PRODUCTION
+
+    docs_dependency = None
+    if show_docs:
+        if is_production and _enable_docs_in_production:
+            docs_dependency = docs_production_dependency if docs_production_dependency is not None else get_current_superuser
+        elif settings.ENVIRONMENT == EnvironmentOption.STAGING:
+            docs_dependency = get_current_superuser
+
     hide_docs = (
         isinstance(settings, EnvironmentSettings)
         and settings.ENVIRONMENT == EnvironmentOption.PRODUCTION
         and not _enable_docs_in_production
     )
-    if hide_docs:
+    if hide_docs or docs_dependency is not None:
+        # Either docs are fully disabled, or only the gated routes below should
+        # serve them - the FastAPI built-in docs routes must not be registered.
         kwargs.update({"docs_url": None, "redoc_url": None, "openapi_url": None})
 
     if lifespan is None:
@@ -293,40 +308,21 @@ def create_application(
         _environment = settings.ENVIRONMENT.value if hasattr(settings, "ENVIRONMENT") else EnvironmentOption.DEVELOPMENT.value
         application.add_middleware(SecurityHeadersMiddleware, environment=_environment)
 
-    show_docs = isinstance(settings, EnvironmentSettings) and (
-        settings.ENVIRONMENT != EnvironmentOption.PRODUCTION or _enable_docs_in_production
-    )
-
     if show_docs:
         docs_router = APIRouter()
 
-        is_production = isinstance(settings, EnvironmentSettings) and settings.ENVIRONMENT == EnvironmentOption.PRODUCTION
-        is_local = isinstance(settings, EnvironmentSettings) and settings.ENVIRONMENT == EnvironmentOption.LOCAL
+        if docs_dependency is not None:
+            docs_router = APIRouter(dependencies=[Depends(docs_dependency)])
 
-        apply_dependency = False
-        dependency_to_apply = None
-
-        if is_production and _enable_docs_in_production:
-            apply_dependency = True
-            dependency_to_apply = (
-                docs_production_dependency if docs_production_dependency is not None else get_current_superuser
-            )
-        elif not is_local and not is_production:
-            apply_dependency = True
-            dependency_to_apply = get_current_superuser
-
-        if apply_dependency and dependency_to_apply is not None:
-            docs_router = APIRouter(dependencies=[Depends(dependency_to_apply)])
-
-        @docs_router.get("/docs", include_in_schema=False)
+        @docs_router.get(_docs_url, include_in_schema=False)
         async def get_swagger_documentation() -> fastapi.responses.HTMLResponse:
-            return get_swagger_ui_html(openapi_url="/openapi.json", title="docs")
+            return get_swagger_ui_html(openapi_url=_openapi_url, title="docs")
 
-        @docs_router.get("/redoc", include_in_schema=False)
+        @docs_router.get(_redoc_url, include_in_schema=False)
         async def get_redoc_documentation() -> fastapi.responses.HTMLResponse:
-            return get_redoc_html(openapi_url="/openapi.json", title="redoc")
+            return get_redoc_html(openapi_url=_openapi_url, title="redoc")
 
-        @docs_router.get("/openapi.json", include_in_schema=False)
+        @docs_router.get(_openapi_url, include_in_schema=False)
         async def openapi() -> dict[str, Any]:
             return get_openapi(
                 title=metadata.get("title", "API"),

--- a/docs/user-guide/api/index.md
+++ b/docs/user-guide/api/index.md
@@ -189,7 +189,7 @@ What ships out of the box (40 total routes):
 | `GET /api/v1/auth/oauth/google`, `oauth/callback/google` | `infrastructure/auth/routes.py` | Google OAuth |
 | `POST/GET/PATCH/DELETE /api/v1/api-keys/*` | `modules/api_keys/routes.py` | Authenticated key management |
 | `GET /admin/*` | `interfaces/admin/initialize.py` | SQLAdmin UI |
-| `GET /docs`, `/redoc`, `/openapi.json` | FastAPI built-ins | Disabled in production unless `ENABLE_DOCS_IN_PRODUCTION=true` |
+| `GET /docs`, `/redoc`, `/openapi.json` | App factory (protected when gated) | Disabled in production unless `ENABLE_DOCS_IN_PRODUCTION=true`; when enabled in production or running in staging, requires superuser authentication |
 | `GET /health` | App factory | Liveness check |
 
 ## What's Next

--- a/docs/user-guide/configuration/environment-variables.md
+++ b/docs/user-guide/configuration/environment-variables.md
@@ -175,9 +175,11 @@ GZIP_MINIMUM_SIZE=1000
 ### API Docs
 
 ```env
-ENABLE_DOCS_IN_PRODUCTION=false  # serve /docs even when ENVIRONMENT=production
+ENABLE_DOCS_IN_PRODUCTION=false  # serve /docs even when ENVIRONMENT=production (superuser-only)
 OPENAPI_PREFIX=                   # path prefix for the OpenAPI schema
 ```
+
+When docs are served outside development (staging, or production with `ENABLE_DOCS_IN_PRODUCTION=true`), the built-in FastAPI docs routes are not registered — `/docs`, `/redoc`, and `/openapi.json` are only reachable through the app's own routes, which require superuser authentication.
 
 ## Authentication & Security
 


### PR DESCRIPTION
The app factory builds a superuser-gated docs router for staging and for production with ENABLE_DOCS_IN_PRODUCTION=true, but FastAPI registers its built-in /docs, /redoc and /openapi.json routes first, so the gated routes never matched and the docs were served publicly in exactly the environments the gate was meant to protect.

This PR passes docs_url=None, redoc_url=None and openapi_url=None to the FastAPI constructor whenever the gated router applies, so only the protected routes exist. The custom router also uses the configured DOCS_URL, REDOC_URL and OPENAPI_URL settings instead of hardcoded paths. Development keeps the public built-in docs, and production without the flag still disables docs entirely. Verified for all four environment combinations.

Written by Kimi, Authored by @emiliano-go
