### PR TITLE
fix: enforce rate limiting in the middleware

### DIFF
--- a/backend/src/infrastructure/rate_limit/middleware.py
+++ b/backend/src/infrastructure/rate_limit/middleware.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from ...modules.common.utils.logger import get_logger
 from ...modules.rate_limit.crud import crud_rate_limits
@@ -13,6 +13,7 @@ from ...modules.tier.crud import crud_tiers
 from ...modules.tier.schemas import TierSelect
 from ..config import get_settings
 from ..database import async_session
+from ..database.session import local_session
 from .exceptions import RateLimitException
 from .provider import increment_and_check
 from .utils import sanitize_path
@@ -135,13 +136,28 @@ class RateLimiterMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process a request through the middleware.
 
+        Enforces the configured rate limit for the request before forwarding it,
+        then copies any rate limit headers onto the response.
+
         Args:
             request: The incoming request.
             call_next: The next middleware or handler in the chain.
 
         Returns:
-            The response from the next middleware or handler.
+            The response from the next middleware or handler, or a 429 response
+            if the rate limit is exceeded.
         """
+        user = await get_optional_user(request)
+        try:
+            async with local_session() as db:
+                await _check_rate_limit(request, db, user)
+        except RateLimitException as e:
+            return JSONResponse(
+                status_code=e.status_code,
+                content={"detail": e.detail},
+                headers=dict(e.headers or {}),
+            )
+
         response = await call_next(request)
 
         if hasattr(request.state, "rate_limit_headers"):

--- a/backend/tests/unit/infrastructure/rate_limit/test_middleware.py
+++ b/backend/tests/unit/infrastructure/rate_limit/test_middleware.py
@@ -187,7 +187,8 @@ async def test_rate_limiter_middleware(mock_request, mock_response, mock_app):
         "X-RateLimit-Reset": "60",
     }
 
-    response = await middleware.dispatch(mock_request, next_handler)
+    with patch("src.infrastructure.rate_limit.middleware._check_rate_limit", new=AsyncMock()):
+        response = await middleware.dispatch(mock_request, next_handler)
 
     assert response.headers["X-RateLimit-Limit"] == "10"
     assert response.headers["X-RateLimit-Remaining"] == "5"
@@ -205,6 +206,40 @@ async def test_rate_limiter_middleware_no_headers(mock_request, mock_response, m
     if hasattr(mock_request.state, "rate_limit_headers"):
         delattr(mock_request.state, "rate_limit_headers")
 
-    response = await middleware.dispatch(mock_request, next_handler)
+    with patch("src.infrastructure.rate_limit.middleware._check_rate_limit", new=AsyncMock()):
+        response = await middleware.dispatch(mock_request, next_handler)
 
     assert len(response.headers) == 0
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_middleware_enforces_limit(mock_request, mock_response, mock_app):
+    """Test that dispatch returns 429 when the rate limit is exceeded."""
+    middleware = RateLimiterMiddleware(app=mock_app)
+
+    async def next_handler(request):
+        return mock_response
+
+    with patch(
+        "src.infrastructure.rate_limit.middleware._check_rate_limit",
+        new=AsyncMock(side_effect=RateLimitException("Rate limit exceeded. Try again in 60 seconds.")),
+    ):
+        response = await middleware.dispatch(mock_request, next_handler)
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "60"
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_middleware_calls_check(mock_request, mock_response, mock_app):
+    """Test that dispatch enforces the rate limit check before forwarding."""
+    middleware = RateLimiterMiddleware(app=mock_app)
+
+    async def next_handler(request):
+        return mock_response
+
+    check = AsyncMock()
+    with patch("src.infrastructure.rate_limit.middleware._check_rate_limit", new=check):
+        await middleware.dispatch(mock_request, next_handler)
+
+    check.assert_called_once()

--- a/docs/user-guide/rate-limiting/index.md
+++ b/docs/user-guide/rate-limiting/index.md
@@ -24,15 +24,14 @@ backend/src/modules/rate_limit/
 └── schemas.py
 ```
 
-The middleware and provider are wired up; the backend is initialized in the app's lifespan. **Enforcement is opt-in per route** — see below.
+The middleware and provider are wired up; the backend is initialized in the app's lifespan. **Enforcement happens in `RateLimiterMiddleware`** — when `RATE_LIMITER_ENABLED=true`, every request is checked before it reaches a route.
 
 ## How a Request Flows Through It
 
-1. **Request arrives**, `RateLimiterMiddleware` is on the stack but **does not enforce limits** — it only attaches `X-RateLimit-*` headers to the response after the handler runs.
-2. **The route's `Depends(check_rate_limit)` runs.** This is the actual enforcement point. Without this dependency on a route, no limit is checked.
-3. **`check_rate_limit` extracts the user** from `request.state.user` (or falls back to client IP for anonymous requests), looks up the user's tier and the matching rate-limit row from the database, and computes `(limit, period)`.
-4. **`increment_and_check`** atomically increments the counter at `ratelimit:{user_or_ip}:{sanitized_path}` and returns `(count, is_limited)`. The TTL on the key is set on first increment to `period` seconds.
-5. **If `is_limited`**, raises `RateLimitException` (HTTP 429). Otherwise, sets `request.state.rate_limit_headers` so the middleware can attach them to the response.
+1. **Request arrives**, `RateLimiterMiddleware.dispatch` runs `check_rate_limit` before forwarding the request. If the limit is exceeded, the middleware short-circuits with a 429 (`RateLimitException`) response.
+2. **`check_rate_limit` extracts the user** from `request.state.user` (or falls back to client IP for anonymous requests), looks up the user's tier and the matching rate-limit row from the database, and computes `(limit, period)`.
+3. **`increment_and_check`** atomically increments the counter at `ratelimit:{user_or_ip}:{sanitized_path}` and returns `(count, is_limited)`. The TTL on the key is set on first increment to `period` seconds.
+4. **If `is_limited`**, raises `RateLimitException` (HTTP 429). Otherwise, sets `request.state.rate_limit_headers` so the middleware can attach them to the response.
 
 The key shape (no window suffix — the TTL handles the window):
 
@@ -40,9 +39,11 @@ The key shape (no window suffix — the TTL handles the window):
 ratelimit:{user_id_or_ip}:{sanitized_path}
 ```
 
-## Enabling Enforcement on a Route
+## Enabling Enforcement
 
-Add the dependency:
+With `RATE_LIMITER_ENABLED=true` (the default), `RateLimiterMiddleware` enforces limits on **every** request automatically — anonymous requests are keyed by client IP and path with the default limit (`DEFAULT_RATE_LIMIT_LIMIT` per `DEFAULT_RATE_LIMIT_PERIOD`).
+
+The `check_rate_limit` dependency is also exported if you want to apply the check manually at the route layer (it is what the middleware calls internally):
 
 ```python
 from fastapi import APIRouter, Depends
@@ -55,16 +56,10 @@ router = APIRouter()
 async def create_widget(...): ...
 ```
 
-Or apply it to every route in a router:
+Applying the dependency in addition to the middleware means the check runs twice for that request, so it's usually unnecessary.
 
-```python
-router = APIRouter(dependencies=[Depends(check_rate_limit)])
-```
-
-That's all that's required — provided the rate limiter is enabled (`RATE_LIMITER_ENABLED=true`), every request to that route is checked.
-
-!!! warning "Currently no built-in route uses `check_rate_limit`"
-    The boilerplate's shipped routes (`/api/v1/users`, `/api/v1/auth`, `/api/v1/tiers`, `/api/v1/rate-limits`, `/api/v1/api-keys`) do **not** apply `check_rate_limit` by default. You add the dependency where you want enforcement. The middleware will still attach `X-RateLimit-*` headers, but only when something has populated `request.state.rate_limit_headers` — which only happens after `check_rate_limit` has run.
+!!! warning "Set sensible defaults"
+    Because the middleware checks every request, `DEFAULT_RATE_LIMIT_LIMIT` / `DEFAULT_RATE_LIMIT_PERIOD` apply to all anonymous traffic (keyed by IP + path). Lower them deliberately, or disable the limiter in tests with `RATE_LIMITER_ENABLED=false`.
 
 ## Configuration
 


### PR DESCRIPTION
RateLimiterMiddleware.dispatch only copied rate-limit headers onto the response; it never ran the check itself, and the check_rate_limit dependency was not used by any route. As a result no HTTP request was ever rate-limited, even with RATE_LIMITER_ENABLED=true (the default).

The middleware now opens a session, resolves the optional user, and runs the existing check before forwarding the request. A raised RateLimitException is converted to a 429 JSON response with a Retry-After header inside the middleware, since the app-level exception handlers sit inside the middleware stack and would never see it. Fail-open and fail-closed semantics are unchanged, and requests without matching tier or limit rules behave as before. Docs updated (they previously described the inert behavior as intentional).

Written by Kimi, Authored by @emiliano-go
