### PR TITLE
fix: atomic counters and consistent windowed keys in rate-limit backends

### DIFF
--- a/backend/src/infrastructure/rate_limit/backends/memcached.py
+++ b/backend/src/infrastructure/rate_limit/backends/memcached.py
@@ -93,14 +93,16 @@ class MemcachedBackend(RateLimiterBackend):
     async def _increment_counter(self, key: bytes, amount: int, expiry: int) -> int:
         """Atomically increment a counter, creating it with an expiry if missing."""
         try:
-            return await self.client.incr(key, amount)
+            result = await self.client.incr(key, amount)
+            return result if result is not None else amount
         except ClientException:
             # Key does not exist yet; add it with the window expiry and retry
             # the incr if a concurrent request created it in the meantime.
             added = await self.client.add(key, str(amount).encode(), exptime=expiry)
             if added:
                 return amount
-            return await self.client.incr(key, amount)
+            result = await self.client.incr(key, amount)
+            return result if result is not None else amount
 
     async def get_count(self, key: str) -> int | None:
         """Get the current count for a key.

--- a/backend/src/infrastructure/rate_limit/backends/memcached.py
+++ b/backend/src/infrastructure/rate_limit/backends/memcached.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 
 try:
     import aiomcache
+    from aiomcache.exceptions import ClientException
 except ImportError:
     raise ImportError(
         "The aiomcache package is not installed. "
@@ -80,11 +81,7 @@ class MemcachedBackend(RateLimiterBackend):
             window_start = current_timestamp - (current_timestamp % period)
             rate_limit_key = f"{key_hash}:{window_start}".encode()
 
-            value = await self.client.get(rate_limit_key)
-            current_count = int(value.decode()) if value else 0
-
-            current_count += 1
-            await self.client.set(rate_limit_key, str(current_count).encode(), exptime=period)
+            current_count = await self._increment_counter(rate_limit_key, amount=1, expiry=period)
 
             is_rate_limited = current_count > limit
             return current_count, is_rate_limited
@@ -92,6 +89,18 @@ class MemcachedBackend(RateLimiterBackend):
         except Exception as e:
             logger.error(f"Error checking rate limit for key {key}: {e}")
             return 0, not self.fail_open
+
+    async def _increment_counter(self, key: bytes, amount: int, expiry: int) -> int:
+        """Atomically increment a counter, creating it with an expiry if missing."""
+        try:
+            return await self.client.incr(key, amount)
+        except ClientException:
+            # Key does not exist yet; add it with the window expiry and retry
+            # the incr if a concurrent request created it in the meantime.
+            added = await self.client.add(key, str(amount).encode(), exptime=expiry)
+            if added:
+                return amount
+            return await self.client.incr(key, amount)
 
     async def get_count(self, key: str) -> int | None:
         """Get the current count for a key.
@@ -134,14 +143,7 @@ class MemcachedBackend(RateLimiterBackend):
             The new value after incrementing
         """
         try:
-            key_bytes = key.encode()
-            value = await self.client.get(key_bytes)
-            current_count = int(value.decode()) if value else 0
-
-            new_count = current_count + amount
-            await self.client.set(key_bytes, str(new_count).encode(), exptime=expiry)
-
-            return new_count
+            return await self._increment_counter(key.encode(), amount=amount, expiry=expiry)
         except Exception as e:
             logger.error(f"Error incrementing count for key {key}: {e}")
             return 0
@@ -156,8 +158,7 @@ class MemcachedBackend(RateLimiterBackend):
             True if deleted, False otherwise
         """
         try:
-            await self.client.delete(key.encode())
-            return True
+            return await self.client.delete(key.encode())
         except Exception as e:
             logger.error(f"Error deleting key {key}: {e}")
             return False

--- a/backend/src/infrastructure/rate_limit/backends/redis.py
+++ b/backend/src/infrastructure/rate_limit/backends/redis.py
@@ -103,6 +103,10 @@ class RedisBackend(RateLimiterBackend):
             logger.error(f"Error checking rate limit for key {key}: {e}")
             return 0, not self.fail_open
 
+    async def _windowed_keys(self, key: str) -> list[str]:
+        """Return all windowed keys (``f"{key}:{window_start}"``) for a base key."""
+        return [k async for k in self.client.scan_iter(match=f"{key}:*")]
+
     async def get_count(self, key: str) -> int | None:
         """Get the current count for a key.
 
@@ -113,10 +117,11 @@ class RedisBackend(RateLimiterBackend):
             The current count or None if the key doesn't exist.
         """
         try:
-            value = await self.client.get(key)
-            if value:
-                return int(value)
-            return None
+            keys = await self._windowed_keys(key)
+            if not keys:
+                return None
+            values = await self.client.mget(keys)
+            return sum(int(value) for value in values if value)
         except Exception as e:
             logger.error(f"Error getting rate limit count for key {key}: {e}")
             return None
@@ -128,7 +133,9 @@ class RedisBackend(RateLimiterBackend):
             key: The rate limit key to reset.
         """
         try:
-            await self.client.delete(key)
+            keys = await self._windowed_keys(key)
+            if keys:
+                await self.client.delete(*keys)
         except Exception as e:
             logger.error(f"Error resetting rate limit for key {key}: {e}")
 
@@ -172,7 +179,8 @@ class RedisBackend(RateLimiterBackend):
             True if deleted, False otherwise
         """
         try:
-            result = await self.client.delete(key)
+            keys = [key, *await self._windowed_keys(key)]
+            result = await self.client.delete(*keys)
             return bool(result)
         except Exception as e:
             logger.error(f"Error deleting key {key}: {e}")

--- a/backend/tests/unit/infrastructure/rate_limit/backends/test_memcached.py
+++ b/backend/tests/unit/infrastructure/rate_limit/backends/test_memcached.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aiomcache.exceptions import ClientException
 
 from src.infrastructure.rate_limit.backends.memcached import (
     MemcachedBackend,
@@ -17,6 +18,8 @@ def mock_aiomcache():
     client_mock = AsyncMock()
     client_mock.get = AsyncMock()
     client_mock.set = AsyncMock()
+    client_mock.add = AsyncMock()
+    client_mock.incr = AsyncMock()
     client_mock.delete = AsyncMock()
     return client_mock
 
@@ -44,42 +47,53 @@ async def test_init_error():
 @pytest.mark.asyncio
 async def test_increment_and_check_new_key(memcached_backend, mock_aiomcache):
     """Test incrementing a counter for a new key."""
-    mock_aiomcache.get.return_value = None
+    mock_aiomcache.incr.side_effect = ClientException(b"NOT_FOUND")
+    mock_aiomcache.add.return_value = True
 
     count, is_limited = await memcached_backend.increment_and_check(key="test:123", limit=5, period=60)
 
     assert count == 1
     assert is_limited is False
 
-    assert mock_aiomcache.get.called
-    assert mock_aiomcache.set.called
+    mock_aiomcache.incr.assert_called_once()
+    mock_aiomcache.add.assert_called_once()
 
-    set_args = mock_aiomcache.set.call_args.args
-    assert set_args[1] == b"1"
-    assert mock_aiomcache.set.call_args.kwargs["exptime"] == 60
+    add_args = mock_aiomcache.add.call_args.args
+    assert add_args[1] == b"1"
+    assert mock_aiomcache.add.call_args.kwargs["exptime"] == 60
 
 
 @pytest.mark.asyncio
 async def test_increment_and_check_existing_key(memcached_backend, mock_aiomcache):
-    """Test incrementing a counter for an existing key."""
-    mock_aiomcache.get.return_value = b"4"
+    """Test incrementing a counter for an existing key atomically."""
+    mock_aiomcache.incr.return_value = 5
 
     count, is_limited = await memcached_backend.increment_and_check(key="test:123", limit=5, period=60)
 
     assert count == 5
     assert is_limited is False
 
-    mock_aiomcache.get.assert_called_once()
-    mock_aiomcache.set.assert_called_once()
+    mock_aiomcache.incr.assert_called_once()
+    mock_aiomcache.add.assert_not_called()
 
-    set_args = mock_aiomcache.set.call_args.args
-    assert set_args[1] == b"5"
+
+@pytest.mark.asyncio
+async def test_increment_and_check_add_race(memcached_backend, mock_aiomcache):
+    """Test that a concurrent add falls back to incrementing the existing key."""
+    mock_aiomcache.incr.side_effect = [ClientException(b"NOT_FOUND"), 2]
+    mock_aiomcache.add.return_value = False
+
+    count, is_limited = await memcached_backend.increment_and_check(key="test:123", limit=5, period=60)
+
+    assert count == 2
+    assert is_limited is False
+    assert mock_aiomcache.incr.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_rate_limited(memcached_backend, mock_aiomcache):
     """Test that requests are rate limited once limit is exceeded."""
-    mock_aiomcache.get.return_value = b"5"
+    mock_aiomcache.incr.return_value = 6
 
     count, is_limited = await memcached_backend.increment_and_check(key="test:123", limit=5, period=60)
 
@@ -126,9 +140,19 @@ async def test_ping_failure(memcached_backend, mock_aiomcache):
 
 
 @pytest.mark.asyncio
+async def test_delete_returns_actual_result(memcached_backend, mock_aiomcache):
+    """Test that delete reflects whether the key existed."""
+    mock_aiomcache.delete.return_value = True
+    assert await memcached_backend.delete("test:123") is True
+
+    mock_aiomcache.delete.return_value = False
+    assert await memcached_backend.delete("test:123") is False
+
+
+@pytest.mark.asyncio
 async def test_increment_error_handling(memcached_backend, mock_aiomcache):
     """Test error handling during increment operation."""
-    mock_aiomcache.get.side_effect = Exception("Connection error")
+    mock_aiomcache.incr.side_effect = Exception("Connection error")
 
     count, is_limited = await memcached_backend.increment_and_check(key="test:123", limit=5, period=60)
 

--- a/backend/tests/unit/infrastructure/rate_limit/backends/test_redis.py
+++ b/backend/tests/unit/infrastructure/rate_limit/backends/test_redis.py
@@ -19,8 +19,19 @@ def mock_redis_client():
     client_mock = AsyncMock()
     client_mock.pipeline = MagicMock(return_value=pipeline_mock)
     client_mock.get = AsyncMock(return_value="1")
+    client_mock.mget = AsyncMock(return_value=["1"])
     client_mock.delete = AsyncMock(return_value=1)
     client_mock.ping = AsyncMock(return_value=True)
+
+    def scan_iter(match=None):
+        async def _gen():
+            for key in client_mock._scan_keys:
+                yield key
+
+        return _gen()
+
+    client_mock._scan_keys = []
+    client_mock.scan_iter = MagicMock(side_effect=scan_iter)
 
     return client_mock, pipeline_mock
 
@@ -83,25 +94,39 @@ async def test_rate_limited(redis_backend):
 
 @pytest.mark.asyncio
 async def test_get_count(redis_backend):
-    """Test getting the current count for a key."""
+    """Test getting the current count sums the windowed keys."""
     backend, client_mock, _ = redis_backend
 
-    client_mock.get.return_value = "3"
+    client_mock._scan_keys = ["test:123:1000", "test:123:1060"]
+    client_mock.mget.return_value = ["2", "1"]
     count = await backend.get_count("test:123")
     assert count == 3
+    client_mock.scan_iter.assert_called_once_with(match="test:123:*")
 
-    client_mock.get.return_value = None
+    client_mock._scan_keys = []
     count = await backend.get_count("test:456")
     assert count is None
 
 
 @pytest.mark.asyncio
 async def test_reset(redis_backend):
-    """Test resetting the counter for a key."""
+    """Test resetting the counter deletes all windowed keys."""
     backend, client_mock, _ = redis_backend
 
+    client_mock._scan_keys = ["test:123:1000", "test:123:1060"]
     await backend.reset("test:123")
-    client_mock.delete.assert_called_once_with("test:123")
+    client_mock.delete.assert_called_once_with("test:123:1000", "test:123:1060")
+
+
+@pytest.mark.asyncio
+async def test_delete_covers_windowed_keys(redis_backend):
+    """Test that delete removes the raw key and any windowed keys."""
+    backend, client_mock, _ = redis_backend
+
+    client_mock._scan_keys = ["test:123:1000"]
+    result = await backend.delete("test:123")
+    assert result is True
+    client_mock.delete.assert_called_once_with("test:123", "test:123:1000")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two correctness fixes in the rate-limit backends:

Memcached: increment and increment_and_check were implemented as get-then-set, which under-counts under concurrency. They now use aiomcache's atomic incr, adding the key with the window expiry when it does not exist and retrying when a concurrent add lost the race. delete now returns the client's actual result instead of always returning True.

Redis: increment_and_check writes windowed keys (key:window_start) while get_count, reset and delete operated on the raw key, so get_count never saw the counters. All three now operate on the windowed keys.

Unit tests extended for both backends.

Written by Kimi, Authored by @emiliano-go
