### PR TITLE
fix: match the most specific exception in the domain error mapping

### DIFF
--- a/backend/src/modules/common/utils/error_handler.py
+++ b/backend/src/modules/common/utils/error_handler.py
@@ -27,9 +27,15 @@ def _generate_support_id() -> str:
 
 
 def map_exception(error: DomainError) -> HTTPException:
-    """Map a domain exception to a corresponding HTTP exception."""
-    for exception_class, mapper in EXCEPTION_MAPPING.items():
-        if isinstance(error, exception_class):
+    """Map a domain exception to a corresponding HTTP exception.
+
+    Walks the exception's MRO and uses the first exact-type match found in
+    EXCEPTION_MAPPING, so the most specific mapping wins regardless of the
+    order entries appear in the mapping.
+    """
+    for exception_class in type(error).__mro__:
+        mapper = EXCEPTION_MAPPING.get(exception_class)
+        if mapper is not None:
             return mapper(str(error))
 
     logger.error(f"Unmapped domain error: {type(error).__name__}: {error}")

--- a/backend/tests/unit/modules/common/test_error_handler.py
+++ b/backend/tests/unit/modules/common/test_error_handler.py
@@ -7,7 +7,11 @@ from httpx import ASGITransport, AsyncClient
 from src.modules.common.constants import GENERIC_ERROR_MESSAGE
 from src.modules.common.exceptions import (
     InsufficientCreditsError,
+    RateLimitNotFoundError,
     ResourceNotFoundError,
+    TierNotFoundError,
+    UserExistsError,
+    UserNotFoundError,
     ValidationError,
 )
 from src.modules.common.utils.error_handler import (
@@ -115,8 +119,6 @@ def test_map_exception_insufficient_credits_preserves_detail():
 
 def test_map_exception_prefers_specific_subclass_mapping():
     """Subclasses of ResourceNotFoundError must use their own mapping, not the parent's."""
-    from src.modules.common.exceptions import RateLimitNotFoundError, TierNotFoundError, UserNotFoundError
-
     assert map_exception(UserNotFoundError("nope")).detail == "User not found."
     assert map_exception(TierNotFoundError("nope")).detail == "The requested tier was not found."
     assert map_exception(RateLimitNotFoundError("nope")).detail == "Rate limit configuration not found."
@@ -126,8 +128,6 @@ def test_map_exception_prefers_specific_subclass_mapping():
 
 def test_map_exception_user_exists_uses_specific_mapping():
     """UserExistsError must not fall through to the generic ResourceExistsError mapping."""
-    from src.modules.common.exceptions import UserExistsError
-
     http_exc = map_exception(UserExistsError(""))
     assert http_exc.status_code == 422
     assert http_exc.detail == "A user with this email or username already exists."

--- a/backend/tests/unit/modules/common/test_error_handler.py
+++ b/backend/tests/unit/modules/common/test_error_handler.py
@@ -113,6 +113,26 @@ def test_map_exception_insufficient_credits_preserves_detail():
     assert "50 more credits" in http_exc.detail
 
 
+def test_map_exception_prefers_specific_subclass_mapping():
+    """Subclasses of ResourceNotFoundError must use their own mapping, not the parent's."""
+    from src.modules.common.exceptions import RateLimitNotFoundError, TierNotFoundError, UserNotFoundError
+
+    assert map_exception(UserNotFoundError("nope")).detail == "User not found."
+    assert map_exception(TierNotFoundError("nope")).detail == "The requested tier was not found."
+    assert map_exception(RateLimitNotFoundError("nope")).detail == "Rate limit configuration not found."
+    # The base class itself still uses the generic not-found mapping
+    assert map_exception(ResourceNotFoundError("nope")).detail == "The requested resource was not found."
+
+
+def test_map_exception_user_exists_uses_specific_mapping():
+    """UserExistsError must not fall through to the generic ResourceExistsError mapping."""
+    from src.modules.common.exceptions import UserExistsError
+
+    http_exc = map_exception(UserExistsError(""))
+    assert http_exc.status_code == 422
+    assert http_exc.detail == "A user with this email or username already exists."
+
+
 def test_handle_exception_returns_generic_for_domain_errors():
     """handle_exception (used by routes) must also return generic messages."""
     exc = ResourceNotFoundError("Payment record #123 not found in DB")


### PR DESCRIPTION
map_exception iterated EXCEPTION_MAPPING in insertion order with isinstance. Because ResourceNotFoundError is listed before its subclasses (UserNotFoundError, TierNotFoundError, RateLimitNotFoundError) and ResourceExistsError before UserExistsError, the specific mappings were unreachable and every subclass got the generic base message (for example TierNotFoundError returned the generic resource-not-found message instead of the tier-specific one).

map_exception now walks the exception's MRO and looks up exact types, so the most specific mapping wins regardless of dict order. Tests added for subclass-specific messages and the base-class fallback.

Written by Kimi, Authored by @emiliano-go
