### PR TITLE
refactor: share backend settings, provider registry and Redis pools between cache and rate-limit

### DIFF
--- a/backend/src/infrastructure/app_factory.py
+++ b/backend/src/infrastructure/app_factory.py
@@ -16,6 +16,7 @@ from fastapi.openapi.utils import get_openapi
 from ..modules.common.utils.error_handler import register_exception_handlers
 from .auth.dependencies import get_current_superuser
 from .auth.setup import auth
+from .backends.redis_pool import close_redis_pools
 from .cache.initialize import close_cache, initialize_cache
 from .config.settings import (
     CacheSettings,
@@ -77,6 +78,10 @@ def lifespan_factory(
 
             if isinstance(settings, RateLimiterSettings) and settings.RATE_LIMITER_ENABLED:
                 await close_rate_limiter()
+
+            # Shared Redis pools outlive individual clients, which never own
+            # them; disconnect them once both subsystems are closed.
+            await close_redis_pools()
 
     return lifespan
 

--- a/backend/src/infrastructure/backends/__init__.py
+++ b/backend/src/infrastructure/backends/__init__.py
@@ -1,0 +1,22 @@
+"""Shared building blocks for connection-oriented infrastructure backends.
+
+This package holds the pieces that are identical between the cache and rate
+limiter subsystems: connection settings models, optional-dependency detection,
+and the generic backend provider registry.
+"""
+
+from importlib.util import find_spec
+
+from .provider import BackendProvider
+from .settings import MemcachedSettings, RedisSettings
+
+MEMCACHED_INSTALLED = find_spec("aiomcache") is not None
+REDIS_INSTALLED = find_spec("redis") is not None
+
+__all__ = [
+    "BackendProvider",
+    "MemcachedSettings",
+    "RedisSettings",
+    "MEMCACHED_INSTALLED",
+    "REDIS_INSTALLED",
+]

--- a/backend/src/infrastructure/backends/provider.py
+++ b/backend/src/infrastructure/backends/provider.py
@@ -4,9 +4,15 @@ Shared by the cache and rate limiter providers, which differ only in the
 backend contract they store and the exception they raise for missing backends.
 """
 
-from typing import Generic, NoReturn, TypeVar
+from typing import Generic, NoReturn, Protocol, TypeVar, runtime_checkable
 
-BackendT = TypeVar("BackendT")
+
+@runtime_checkable
+class Pingable(Protocol):
+    async def ping(self) -> bool: ...
+
+
+BackendT = TypeVar("BackendT", bound=Pingable)
 
 
 class BackendProvider(Generic[BackendT]):

--- a/backend/src/infrastructure/backends/provider.py
+++ b/backend/src/infrastructure/backends/provider.py
@@ -1,0 +1,93 @@
+"""Generic provider registry for storage backends.
+
+Shared by the cache and rate limiter providers, which differ only in the
+backend contract they store and the exception they raise for missing backends.
+"""
+
+from typing import Generic, NoReturn, TypeVar
+
+BackendT = TypeVar("BackendT")
+
+
+class BackendProvider(Generic[BackendT]):
+    """Registry of named backends with a default backend.
+
+    Subclasses must implement ``_raise_not_found`` to raise the
+    subsystem-specific exception for a missing backend.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the provider with no registered backends."""
+        self._backends: dict[str, BackendT] = {}
+        self._default_backend: str | None = None
+
+    def _raise_not_found(self, name: str | None, *, for_default: bool = False) -> NoReturn:
+        raise NotImplementedError
+
+    def register_backend(self, name: str, backend: BackendT, default: bool = False) -> None:
+        """Register a backend.
+
+        Args:
+            name: The name of the backend.
+            backend: The backend instance.
+            default: Whether this backend should be the default.
+        """
+        self._backends[name] = backend
+        if default or self._default_backend is None:
+            self._default_backend = name
+
+    def get_backend(self, name: str | None = None) -> BackendT:
+        """Get a backend by name, or the default backend if no name is given.
+
+        Args:
+            name: The name of the backend to get. If None, the default backend is returned.
+
+        Returns:
+            The requested backend.
+
+        Raises:
+            The subsystem's backend-not-found error if the backend is not available.
+        """
+        backend_name = name or self._default_backend
+        if backend_name is None or backend_name not in self._backends:
+            self._raise_not_found(backend_name)
+
+        return self._backends[backend_name]
+
+    def set_default_backend(self, name: str) -> None:
+        """Set the default backend to use.
+
+        Args:
+            name: The name of the backend to set as default.
+
+        Raises:
+            The subsystem's backend-not-found error if the backend does not exist.
+        """
+        if name not in self._backends:
+            self._raise_not_found(name, for_default=True)
+
+        self._default_backend = name
+
+    async def ping_all(self) -> dict[str, bool]:
+        """Ping all registered backends.
+
+        Returns:
+            A dictionary mapping backend names to their availability.
+        """
+        results = {}
+        for name, backend in self._backends.items():
+            results[name] = await backend.ping()
+        return results
+
+    def list_backends(self) -> dict[str, type[BackendT]]:
+        """List all registered backends.
+
+        Returns:
+            A dictionary mapping backend names to their types.
+        """
+        return {name: type(backend) for name, backend in self._backends.items()}
+
+    @property
+    def default_backend_name(self) -> str | None:
+        """Get the name of the default backend, or None if no backends are registered."""
+        return self._default_backend

--- a/backend/src/infrastructure/backends/redis_pool.py
+++ b/backend/src/infrastructure/backends/redis_pool.py
@@ -1,0 +1,61 @@
+"""Shared Redis connection pools.
+
+Pools are keyed by their connection parameters so that subsystems (cache,
+rate limiter) pointing at the same server reuse a single pool instead of each
+opening their own. Clients built on a shared pool do not own it: redis-py sets
+``auto_close_connection_pool = False`` when a pool is passed in, so closing a
+client never tears down the pool. Pools are closed centrally via
+``close_redis_pools()`` during application shutdown.
+"""
+
+from redis.asyncio import ConnectionPool
+
+from .settings import RedisSettings
+
+_pools: dict[tuple, ConnectionPool] = {}
+
+
+def _pool_key(settings: RedisSettings) -> tuple:
+    return (
+        settings.host,
+        settings.port,
+        settings.db,
+        settings.password,
+        settings.pool_size,
+        settings.connect_timeout,
+    )
+
+
+def get_redis_pool(settings: RedisSettings) -> ConnectionPool:
+    """Get the shared connection pool for the given settings.
+
+    Identical settings return the same pool; differing settings get their own.
+
+    Args:
+        settings: Redis connection settings.
+
+    Returns:
+        The shared connection pool for those settings.
+    """
+    key = _pool_key(settings)
+    pool = _pools.get(key)
+    if pool is None:
+        pool = ConnectionPool(
+            host=settings.host,
+            port=settings.port,
+            db=settings.db,
+            password=settings.password,
+            socket_timeout=settings.connect_timeout,
+            socket_connect_timeout=settings.connect_timeout,
+            socket_keepalive=True,
+            max_connections=settings.pool_size,
+        )
+        _pools[key] = pool
+    return pool
+
+
+async def close_redis_pools() -> None:
+    """Disconnect and forget all shared pools. Safe to call when none exist."""
+    for pool in _pools.values():
+        await pool.disconnect()
+    _pools.clear()

--- a/backend/src/infrastructure/backends/settings.py
+++ b/backend/src/infrastructure/backends/settings.py
@@ -1,0 +1,49 @@
+"""Shared connection settings models for storage backends.
+
+These models are used by both the cache and rate limiter subsystems so that
+their backends can share a single configuration definition.
+"""
+
+from pydantic import BaseModel
+
+
+class RedisSettings(BaseModel):
+    """Settings for Redis connection.
+
+    This class defines the configuration for connecting to a Redis server.
+
+    Attributes:
+        host: Redis server hostname. Default is "localhost".
+        port: Redis server port. Default is 6379.
+        db: Redis database number. Default is 0.
+        password: Redis server password. Default is None.
+        connect_timeout: Connection timeout in seconds. Default is 5.
+        pool_size: Maximum number of connections in the pool. Default is 10.
+    """
+
+    host: str = "localhost"
+    port: int = 6379
+    db: int = 0
+    password: str | None = None
+    connect_timeout: int = 5
+    pool_size: int = 10
+
+
+class MemcachedSettings(BaseModel):
+    """Settings for Memcached connection.
+
+    This class defines the configuration for connecting to a Memcached server.
+
+    Attributes:
+        host: Memcached server hostname. Default is "localhost".
+        port: Memcached server port. Default is 11211.
+        pool_size: Maximum number of connections in the pool. Default is 10.
+        connect_timeout: Connection timeout in seconds. Default is 5.
+            Note: This parameter is not currently used by aiomcache.Client but is
+            kept for API consistency across backends.
+    """
+
+    host: str = "localhost"
+    port: int = 11211
+    pool_size: int = 10
+    connect_timeout: int = 5

--- a/backend/src/infrastructure/cache/__init__.py
+++ b/backend/src/infrastructure/cache/__init__.py
@@ -1,11 +1,7 @@
-from importlib.util import find_spec
-
+from ..backends import MEMCACHED_INSTALLED, REDIS_INSTALLED
 from .base import CacheBackend
 from .decorator import cache
 from .provider import cache_provider, clear, delete, delete_pattern, exists, get, set
-
-MEMCACHED_INSTALLED = find_spec("aiomcache") is not None
-REDIS_INSTALLED = find_spec("redis.asyncio") is not None
 
 if MEMCACHED_INSTALLED:
     from .backends.memcached import MemcachedBackend, MemcachedSettings

--- a/backend/src/infrastructure/cache/backends/__init__.py
+++ b/backend/src/infrastructure/cache/backends/__init__.py
@@ -5,10 +5,7 @@ This module contains implementations of various cache backends that follow the
 CacheBackend interface.
 """
 
-from importlib.util import find_spec
-
-MEMCACHED_INSTALLED = find_spec("aiomcache") is not None
-REDIS_INSTALLED = find_spec("redis.asyncio") is not None
+from ...backends import MEMCACHED_INSTALLED, REDIS_INSTALLED
 
 if MEMCACHED_INSTALLED:
     from .memcached import (

--- a/backend/src/infrastructure/cache/backends/memcached.py
+++ b/backend/src/infrastructure/cache/backends/memcached.py
@@ -9,13 +9,9 @@ except ImportError:
         "Please install it with 'pip install aiomcache' or 'pip install -e \".[memcached]\"'"
     )
 
-from pydantic import BaseModel
-
-from ...config.settings import get_settings
+from ...backends import MemcachedSettings
 from ..base import CacheBackend
 from ..exceptions import CacheException
-
-settings = get_settings()
 
 
 class PatternMatchingNotSupportedError(CacheException):
@@ -24,26 +20,6 @@ class PatternMatchingNotSupportedError(CacheException):
     def __init__(self, pattern: str):
         self.message = f"Memcached doesn't support pattern-based deletion. Pattern '{pattern}' cannot be used."
         super().__init__(self.message)
-
-
-class MemcachedSettings(BaseModel):
-    """Settings for Memcached connection.
-
-    This class defines the configuration for connecting to a Memcached server.
-
-    Attributes:
-        host: Memcached server hostname. Default is "localhost".
-        port: Memcached server port. Default is 11211.
-        pool_size: Maximum number of connections in the pool. Default is 10.
-        connect_timeout: Connection timeout in seconds. Default is 5.
-            Note: This parameter is not currently used by aiomcache.Client but is
-            kept for API consistency with other cache backends.
-    """
-
-    host: str = "localhost"
-    port: int = 11211
-    pool_size: int = 10
-    connect_timeout: int = 5
 
 
 class MemcachedBackend(CacheBackend):

--- a/backend/src/infrastructure/cache/backends/redis.py
+++ b/backend/src/infrastructure/cache/backends/redis.py
@@ -8,34 +8,8 @@ except ImportError:
         "The redis package is not installed. Please install it with 'pip install redis' or 'pip install -e \".[redis]\"'"
     )
 
-from pydantic import BaseModel
-
-from ...config.settings import get_settings
+from ...backends import RedisSettings
 from ..base import CacheBackend
-
-settings = get_settings()
-
-
-class RedisSettings(BaseModel):
-    """Settings for Redis connection.
-
-    This class defines the configuration for connecting to a Redis server.
-
-    Attributes:
-        host: Redis server hostname. Default is "localhost".
-        port: Redis server port. Default is 6379.
-        db: Redis database number. Default is 0.
-        password: Redis server password. Default is None.
-        connect_timeout: Connection timeout in seconds. Default is 5.
-        pool_size: Maximum number of connections in the pool. Default is 10.
-    """
-
-    host: str = "localhost"
-    port: int = 6379
-    db: int = 0
-    password: str | None = None
-    connect_timeout: int = 5
-    pool_size: int = 10
 
 
 class RedisBackend(CacheBackend):

--- a/backend/src/infrastructure/cache/backends/redis.py
+++ b/backend/src/infrastructure/cache/backends/redis.py
@@ -9,6 +9,7 @@ except ImportError:
     )
 
 from ...backends import RedisSettings
+from ...backends.redis_pool import get_redis_pool
 from ..base import CacheBackend
 
 
@@ -22,14 +23,7 @@ class RedisBackend(CacheBackend):
             settings: Custom settings for Redis connection. If None, default settings are used.
         """
         self.settings = settings or RedisSettings()
-        self.client = Redis(
-            host=self.settings.host,
-            port=self.settings.port,
-            db=self.settings.db,
-            password=self.settings.password,
-            socket_timeout=self.settings.connect_timeout,
-            max_connections=self.settings.pool_size,
-        )
+        self.client = Redis(connection_pool=get_redis_pool(self.settings))
 
     async def get(self, key: str) -> Any | None:
         """Get a value from the cache.

--- a/backend/src/infrastructure/cache/initialize.py
+++ b/backend/src/infrastructure/cache/initialize.py
@@ -1,9 +1,13 @@
 """Module for initializing the cache backends."""
 
-from ..config import CacheBackend
+from ...modules.common.utils.logger import get_logger
+from ..config import CacheBackendType
 from ..config.settings import get_settings
 from . import MEMCACHED_INSTALLED, REDIS_INSTALLED
+from .exceptions import BackendNotFoundError
 from .provider import cache_provider
+
+logger = get_logger(__name__)
 
 if MEMCACHED_INSTALLED:
     from .backends import MemcachedBackend, MemcachedSettings
@@ -23,7 +27,7 @@ async def initialize_cache() -> None:
     if not settings.CACHE_ENABLED:
         return
 
-    if settings.CACHE_BACKEND == CacheBackend.MEMCACHED.value:
+    if settings.CACHE_BACKEND == CacheBackendType.MEMCACHED.value:
         if not MEMCACHED_INSTALLED:
             raise ImportError("The aiomcache package is not installed. Please install it with 'pip install aiomcache'.")
 
@@ -34,9 +38,9 @@ async def initialize_cache() -> None:
             connect_timeout=settings.CACHE_MEMCACHED_CONNECT_TIMEOUT,
         )
         memcached_backend = MemcachedBackend(settings=memcached_settings)
-        cache_provider.register_backend(CacheBackend.MEMCACHED.value, memcached_backend, default=True)
+        cache_provider.register_backend(CacheBackendType.MEMCACHED.value, memcached_backend, default=True)
 
-    elif settings.CACHE_BACKEND == CacheBackend.REDIS.value:
+    elif settings.CACHE_BACKEND == CacheBackendType.REDIS.value:
         if not REDIS_INSTALLED:
             raise ImportError("The redis package is not installed. Please install it with 'pip install redis'.")
 
@@ -49,7 +53,7 @@ async def initialize_cache() -> None:
             pool_size=settings.CACHE_REDIS_POOL_SIZE,
         )
         redis_backend = RedisBackend(settings=redis_settings)
-        cache_provider.register_backend(CacheBackend.REDIS.value, redis_backend, default=True)
+        cache_provider.register_backend(CacheBackendType.REDIS.value, redis_backend, default=True)
 
 
 async def close_cache() -> None:
@@ -62,12 +66,20 @@ async def close_cache() -> None:
     if not settings.CACHE_ENABLED:
         return
 
-    if settings.CACHE_BACKEND == CacheBackend.MEMCACHED.value and MEMCACHED_INSTALLED:
-        backend = cache_provider.get_backend(CacheBackend.MEMCACHED.value)
+    if settings.CACHE_BACKEND == CacheBackendType.MEMCACHED.value and MEMCACHED_INSTALLED:
+        try:
+            backend = cache_provider.get_backend(CacheBackendType.MEMCACHED.value)
+        except BackendNotFoundError:
+            logger.debug("Cache backend 'memcached' was never initialized; nothing to close.")
+            return
         if hasattr(backend, "client") and hasattr(backend.client, "close"):
             await backend.client.close()
 
-    elif settings.CACHE_BACKEND == CacheBackend.REDIS.value and REDIS_INSTALLED:
-        backend = cache_provider.get_backend(CacheBackend.REDIS.value)
+    elif settings.CACHE_BACKEND == CacheBackendType.REDIS.value and REDIS_INSTALLED:
+        try:
+            backend = cache_provider.get_backend(CacheBackendType.REDIS.value)
+        except BackendNotFoundError:
+            logger.debug("Cache backend 'redis' was never initialized; nothing to close.")
+            return
         if hasattr(backend, "client") and hasattr(backend.client, "close"):
             await backend.client.close()

--- a/backend/src/infrastructure/cache/provider.py
+++ b/backend/src/infrastructure/cache/provider.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Any, NoReturn
 
+from ..backends import BackendProvider
 from .base import CacheBackend
 from .exceptions import BackendNotFoundError
 
 
-class CacheProvider:
+class CacheProvider(BackendProvider[CacheBackend]):
     """Provider for cache backends.
 
     This class manages the different cache backends and provides a single point of access
@@ -12,82 +13,10 @@ class CacheProvider:
     between them at runtime.
     """
 
-    def __init__(self) -> None:
-        """Initialize the cache provider."""
-        self._backends: dict[str, CacheBackend] = {}
-        self._default_backend: str | None = None
-
-    def register_backend(self, name: str, backend: CacheBackend, default: bool = False) -> None:
-        """Register a cache backend.
-
-        Args:
-            name: The name of the backend.
-            backend: The backend instance.
-            default: Whether this backend should be the default.
-        """
-        self._backends[name] = backend
-        if default or self._default_backend is None:
-            self._default_backend = name
-
-    def get_backend(self, name: str | None = None) -> CacheBackend:
-        """Get a cache backend by name.
-
-        Args:
-            name: The name of the backend to get. If None, the default backend is returned.
-
-        Returns:
-            The requested cache backend.
-
-        Raises:
-            BackendNotFoundError: If the requested backend is not available.
-        """
-        backend_name = name or self._default_backend
-        if backend_name is None or backend_name not in self._backends:
-            raise BackendNotFoundError(f"Backend '{backend_name}' is not available.")
-
-        return self._backends[backend_name]
-
-    def set_default_backend(self, name: str) -> None:
-        """Set the default backend to use.
-
-        Args:
-            name: The name of the backend to set as default.
-
-        Raises:
-            BackendNotFoundError: If the backend does not exist.
-        """
-        if name not in self._backends:
+    def _raise_not_found(self, name: str | None, *, for_default: bool = False) -> NoReturn:
+        if for_default:
             raise BackendNotFoundError(f"Backend '{name}' not found. Cannot set as default.")
-
-        self._default_backend = name
-
-    async def ping_all(self) -> dict[str, bool]:
-        """Ping all registered backends.
-
-        Returns:
-            A dictionary mapping backend names to their availability.
-        """
-        results = {}
-        for name, backend in self._backends.items():
-            results[name] = await backend.ping()
-        return results
-
-    def list_backends(self) -> dict[str, type[CacheBackend]]:
-        """List all registered backends.
-
-        Returns:
-            A dictionary mapping backend names to their types.
-        """
-        return {name: type(backend) for name, backend in self._backends.items()}
-
-    @property
-    def default_backend_name(self) -> str | None:
-        """Get the name of the default backend.
-
-        Returns:
-            The name of the default backend, or None if no backends are registered.
-        """
-        return self._default_backend
+        raise BackendNotFoundError(f"Backend '{name}' is not available.")
 
 
 cache_provider = CacheProvider()

--- a/backend/src/infrastructure/config/__init__.py
+++ b/backend/src/infrastructure/config/__init__.py
@@ -1,10 +1,10 @@
-from .enums import CacheBackend, LogFormat, LogLevel, SessionBackend, TaskiqBrokerType
+from .enums import CacheBackendType, LogFormat, LogLevel, SessionBackend, TaskiqBrokerType
 from .settings import get_settings, settings
 
 __all__ = [
     "settings",
     "get_settings",
-    "CacheBackend",
+    "CacheBackendType",
     "SessionBackend",
     "TaskiqBrokerType",
     "LogLevel",

--- a/backend/src/infrastructure/config/enums.py
+++ b/backend/src/infrastructure/config/enums.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 
 
-class CacheBackend(StrEnum):
+class CacheBackendType(StrEnum):
     """Cache backend types.
 
     Supported backends for caching and rate limiting.

--- a/backend/src/infrastructure/config/settings.py
+++ b/backend/src/infrastructure/config/settings.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 from starlette.config import Config
 
-from .enums import CacheBackend, LogFormat, LogLevel, SessionBackend, TaskiqBrokerType
+from .enums import CacheBackendType, LogFormat, LogLevel, SessionBackend, TaskiqBrokerType
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class CacheSettings(BaseSettings):
     """
 
     CACHE_ENABLED: bool = config("CACHE_ENABLED", default=True, cast=bool)
-    CACHE_BACKEND: str = config("CACHE_BACKEND", default=CacheBackend.MEMCACHED.value)
+    CACHE_BACKEND: str = config("CACHE_BACKEND", default=CacheBackendType.MEMCACHED.value)
 
     CACHE_MEMCACHED_HOST: str = config("CACHE_MEMCACHED_HOST", default="localhost")
     CACHE_MEMCACHED_PORT: int = config("CACHE_MEMCACHED_PORT", default=11211, cast=int)
@@ -162,7 +162,7 @@ class RateLimiterSettings(BaseSettings):
     """
 
     RATE_LIMITER_ENABLED: bool = config("RATE_LIMITER_ENABLED", default=True, cast=bool)
-    RATE_LIMITER_BACKEND: str = config("RATE_LIMITER_BACKEND", default=CacheBackend.MEMCACHED.value)
+    RATE_LIMITER_BACKEND: str = config("RATE_LIMITER_BACKEND", default=CacheBackendType.MEMCACHED.value)
     RATE_LIMITER_FAIL_OPEN: bool = config("RATE_LIMITER_FAIL_OPEN", default=True, cast=bool)
 
     DEFAULT_RATE_LIMIT_LIMIT: int = config("DEFAULT_RATE_LIMIT_LIMIT", default=100, cast=int)

--- a/backend/src/infrastructure/rate_limit/__init__.py
+++ b/backend/src/infrastructure/rate_limit/__init__.py
@@ -4,17 +4,13 @@ This module contains the rate limiting infrastructure components, including midd
 and backend implementations.
 """
 
-import importlib.util
-
+from ..backends import MEMCACHED_INSTALLED, REDIS_INSTALLED
 from .base import RateLimiterBackend
 from .exceptions import RateLimiterBackendException, RateLimitException
 from .initialize import close_rate_limiter, initialize_rate_limiter
 from .middleware import RateLimiterMiddleware, _check_rate_limit, check_rate_limit
 from .provider import get_count, increment_and_check, rate_limiter_provider, reset
 from .utils import sanitize_path
-
-MEMCACHED_INSTALLED = importlib.util.find_spec("aiomcache") is not None
-REDIS_INSTALLED = importlib.util.find_spec("redis") is not None
 
 __all__ = [
     "RateLimiterMiddleware",

--- a/backend/src/infrastructure/rate_limit/backends/__init__.py
+++ b/backend/src/infrastructure/rate_limit/backends/__init__.py
@@ -3,10 +3,7 @@
 This package contains implementations of rate limiter backends for different storage engines.
 """
 
-import importlib.util
-
-MEMCACHED_INSTALLED = importlib.util.find_spec("aiomcache") is not None
-REDIS_INSTALLED = importlib.util.find_spec("redis") is not None
+from ...backends import MEMCACHED_INSTALLED, REDIS_INSTALLED
 
 if MEMCACHED_INSTALLED:
     from .memcached import MemcachedBackend, MemcachedSettings  # noqa: F401

--- a/backend/src/infrastructure/rate_limit/backends/memcached.py
+++ b/backend/src/infrastructure/rate_limit/backends/memcached.py
@@ -9,33 +9,12 @@ except ImportError:
         "Please install it with 'pip install aiomcache' or 'pip install -e \".[memcached]\"'"
     )
 
-from pydantic import BaseModel
-
 from ....modules.common.utils.logger import get_logger
+from ...backends import MemcachedSettings
 from ..base import RateLimiterBackend
 from ..exceptions import RateLimiterBackendException
 
 logger = get_logger(__name__)
-
-
-class MemcachedSettings(BaseModel):
-    """Settings for Memcached connection.
-
-    This class defines the configuration for connecting to a Memcached server.
-
-    Attributes:
-        host: Memcached server hostname. Default is "localhost".
-        port: Memcached server port. Default is 11211.
-        pool_size: Maximum number of connections in the pool. Default is 10.
-        connect_timeout: Connection timeout in seconds. Default is 5.
-            Note: This parameter is not currently used by aiomcache.Client but is
-            kept for API consistency with other rate limiter backends.
-    """
-
-    host: str = "localhost"
-    port: int = 11211
-    pool_size: int = 10
-    connect_timeout: int = 5
 
 
 class MemcachedBackend(RateLimiterBackend):

--- a/backend/src/infrastructure/rate_limit/backends/redis.py
+++ b/backend/src/infrastructure/rate_limit/backends/redis.py
@@ -8,35 +8,12 @@ except ImportError:
         "The redis package is not installed. Please install it with 'pip install redis' or 'pip install -e \".[redis]\"'"
     )
 
-from pydantic import BaseModel
-
 from ....modules.common.utils.logger import get_logger
+from ...backends import RedisSettings
 from ..base import RateLimiterBackend
 from ..exceptions import RateLimiterBackendException
 
 logger = get_logger(__name__)
-
-
-class RedisSettings(BaseModel):
-    """Settings for Redis connection.
-
-    This class defines the configuration for connecting to a Redis server.
-
-    Attributes:
-        host: Redis server hostname. Default is "localhost".
-        port: Redis server port. Default is 6379.
-        db: Redis database number. Default is 0.
-        password: Redis server password. Default is None.
-        connect_timeout: Connection timeout in seconds. Default is 5.
-        pool_size: Maximum number of connections in the pool. Default is 10.
-    """
-
-    host: str = "localhost"
-    port: int = 6379
-    db: int = 0
-    password: str | None = None
-    connect_timeout: int = 5
-    pool_size: int = 10
 
 
 class RedisBackend(RateLimiterBackend):

--- a/backend/src/infrastructure/rate_limit/backends/redis.py
+++ b/backend/src/infrastructure/rate_limit/backends/redis.py
@@ -10,6 +10,7 @@ except ImportError:
 
 from ....modules.common.utils.logger import get_logger
 from ...backends import RedisSettings
+from ...backends.redis_pool import get_redis_pool
 from ..base import RateLimiterBackend
 from ..exceptions import RateLimiterBackendException
 
@@ -30,17 +31,9 @@ class RedisBackend(RateLimiterBackend):
         super().__init__(fail_open=fail_open)
         self.settings = settings or RedisSettings()
         try:
-            self.client = Redis(
-                host=self.settings.host,
-                port=self.settings.port,
-                db=self.settings.db,
-                password=self.settings.password,
-                socket_timeout=self.settings.connect_timeout,
-                socket_connect_timeout=self.settings.connect_timeout,
-                socket_keepalive=True,
-                decode_responses=True,
-                max_connections=self.settings.pool_size,
-            )
+            # Shared pools are created with decode_responses=False; this backend
+            # decodes the only string value it reads (get_count) itself.
+            self.client = Redis(connection_pool=get_redis_pool(self.settings))
         except Exception as e:
             logger.error(f"Failed to initialize Redis client: {e}")
             raise RateLimiterBackendException(f"Failed to initialize Redis client: {e}")
@@ -92,7 +85,7 @@ class RedisBackend(RateLimiterBackend):
         try:
             value = await self.client.get(key)
             if value:
-                return int(value)
+                return int(value.decode() if isinstance(value, bytes) else value)
             return None
         except Exception as e:
             logger.error(f"Error getting rate limit count for key {key}: {e}")

--- a/backend/src/infrastructure/rate_limit/initialize.py
+++ b/backend/src/infrastructure/rate_limit/initialize.py
@@ -1,12 +1,12 @@
 """Module for initializing the rate limiter backends."""
 
-import importlib.util
-
-from ..config import CacheBackend, get_settings
+from ...modules.common.utils.logger import get_logger
+from ..backends import MEMCACHED_INSTALLED, REDIS_INSTALLED
+from ..config import CacheBackendType, get_settings
+from .exceptions import BackendNotFoundError
 from .provider import rate_limiter_provider
 
-MEMCACHED_INSTALLED = importlib.util.find_spec("aiomcache") is not None
-REDIS_INSTALLED = importlib.util.find_spec("redis") is not None
+logger = get_logger(__name__)
 
 if MEMCACHED_INSTALLED:
     from .backends import MemcachedBackend, MemcachedSettings
@@ -26,7 +26,7 @@ async def initialize_rate_limiter() -> None:
     if not settings.RATE_LIMITER_ENABLED:
         return
 
-    if settings.RATE_LIMITER_BACKEND == CacheBackend.MEMCACHED.value:
+    if settings.RATE_LIMITER_BACKEND == CacheBackendType.MEMCACHED.value:
         if not MEMCACHED_INSTALLED:
             raise ImportError("The aiomcache package is not installed. Please install it with 'pip install aiomcache'.")
 
@@ -36,9 +36,9 @@ async def initialize_rate_limiter() -> None:
             pool_size=settings.RATE_LIMITER_MEMCACHED_POOL_SIZE,
         )
         memcached_backend = MemcachedBackend(settings=memcached_settings, fail_open=settings.RATE_LIMITER_FAIL_OPEN)
-        rate_limiter_provider.register_backend(CacheBackend.MEMCACHED.value, memcached_backend, default=True)
+        rate_limiter_provider.register_backend(CacheBackendType.MEMCACHED.value, memcached_backend, default=True)
 
-    elif settings.RATE_LIMITER_BACKEND == CacheBackend.REDIS.value:
+    elif settings.RATE_LIMITER_BACKEND == CacheBackendType.REDIS.value:
         if not REDIS_INSTALLED:
             raise ImportError("The redis package is not installed. Please install it with 'pip install redis'.")
 
@@ -51,7 +51,7 @@ async def initialize_rate_limiter() -> None:
             pool_size=settings.RATE_LIMITER_REDIS_POOL_SIZE,
         )
         redis_backend = RedisBackend(settings=redis_settings, fail_open=settings.RATE_LIMITER_FAIL_OPEN)
-        rate_limiter_provider.register_backend(CacheBackend.REDIS.value, redis_backend, default=True)
+        rate_limiter_provider.register_backend(CacheBackendType.REDIS.value, redis_backend, default=True)
 
 
 async def close_rate_limiter() -> None:
@@ -64,12 +64,20 @@ async def close_rate_limiter() -> None:
     if not settings.RATE_LIMITER_ENABLED:
         return
 
-    if settings.RATE_LIMITER_BACKEND == CacheBackend.MEMCACHED.value and MEMCACHED_INSTALLED:
-        backend = rate_limiter_provider.get_backend(CacheBackend.MEMCACHED.value)
+    if settings.RATE_LIMITER_BACKEND == CacheBackendType.MEMCACHED.value and MEMCACHED_INSTALLED:
+        try:
+            backend = rate_limiter_provider.get_backend(CacheBackendType.MEMCACHED.value)
+        except BackendNotFoundError:
+            logger.debug("Rate limiter backend 'memcached' was never initialized; nothing to close.")
+            return
         if hasattr(backend, "client") and hasattr(backend.client, "close"):
             await backend.client.close()
 
-    elif settings.RATE_LIMITER_BACKEND == CacheBackend.REDIS.value and REDIS_INSTALLED:
-        backend = rate_limiter_provider.get_backend(CacheBackend.REDIS.value)
+    elif settings.RATE_LIMITER_BACKEND == CacheBackendType.REDIS.value and REDIS_INSTALLED:
+        try:
+            backend = rate_limiter_provider.get_backend(CacheBackendType.REDIS.value)
+        except BackendNotFoundError:
+            logger.debug("Rate limiter backend 'redis' was never initialized; nothing to close.")
+            return
         if hasattr(backend, "client") and hasattr(backend.client, "close"):
             await backend.client.close()

--- a/backend/src/infrastructure/rate_limit/provider.py
+++ b/backend/src/infrastructure/rate_limit/provider.py
@@ -39,7 +39,7 @@ class RateLimiterProvider(BackendProvider[RateLimiterBackend]):
 
     def _raise_not_found(self, name: str | None, *, for_default: bool = False) -> NoReturn:
         if for_default:
-            raise BackendNotFoundError(name)
+            raise BackendNotFoundError(name or "default")
         raise BackendNotFoundError(name or "default")
 
 

--- a/backend/src/infrastructure/rate_limit/provider.py
+++ b/backend/src/infrastructure/rate_limit/provider.py
@@ -1,8 +1,11 @@
+from typing import NoReturn
+
+from ..backends import BackendProvider
 from .base import RateLimiterBackend
 from .exceptions import BackendNotFoundError
 
 
-class RateLimiterProvider:
+class RateLimiterProvider(BackendProvider[RateLimiterBackend]):
     """Provider for rate limiter backends with comprehensive backend management.
 
     This class manages multiple rate limiter backends and provides a centralized
@@ -34,195 +37,10 @@ class RateLimiterProvider:
         ```
     """
 
-    def __init__(self) -> None:
-        """Initialize the rate limiter provider.
-
-        Creates an empty provider with no registered backends. Backends must be
-        registered before use via register_backend().
-
-        Note:
-            The provider starts with no default backend. The first registered
-            backend becomes the default, or you can explicitly set a default
-            using the default=True parameter in register_backend().
-        """
-        self._backends: dict[str, RateLimiterBackend] = {}
-        self._default_backend: str | None = None
-
-    def register_backend(self, name: str, backend: RateLimiterBackend, default: bool = False) -> None:
-        """Register a rate limiter backend with the provider.
-
-        Adds a backend to the provider's registry, making it available for
-        rate limiting operations. Optionally sets the backend as the default.
-
-        Args:
-            name: The name of the backend for identification and retrieval.
-            backend: The backend instance to register.
-            default: Whether this backend should be the default. If True, or if
-                    no default is set, this backend becomes the default.
-
-        Note:
-            Backend names should be unique within the provider. Registering
-            a backend with an existing name will replace the previous backend.
-
-            The first registered backend automatically becomes the default
-            unless explicitly overridden.
-
-        Example:
-            ```python
-            # Register primary Redis backend
-            provider.register_backend(
-                "redis-primary",
-                RedisRateLimiterBackend(host="redis-primary.example.com"),
-                default=True
-            )
-
-            # Register backup Redis backend
-            provider.register_backend(
-                "redis-backup",
-                RedisRateLimiterBackend(host="redis-backup.example.com")
-            )
-            ```
-        """
-        self._backends[name] = backend
-        if default or self._default_backend is None:
-            self._default_backend = name
-
-    def get_backend(self, name: str | None = None) -> RateLimiterBackend:
-        """Get a rate limiter backend by name.
-
-        Retrieves a registered backend by name, or returns the default backend
-        if no name is specified.
-
-        Args:
-            name: The name of the backend to retrieve. If None, returns the
-                 default backend.
-
-        Returns:
-            The requested rate limiter backend.
-
-        Raises:
-            BackendNotFoundError: If the requested backend is not found or
-                                 no default backend is available.
-
-        Example:
-            ```python
-            # Get default backend
-            default_backend = provider.get_backend()
-
-            # Get specific backend
-            redis_backend = provider.get_backend("redis")
-
-            # Handle missing backend
-            try:
-                backend = provider.get_backend("nonexistent")
-            except BackendNotFoundError:
-                backend = provider.get_backend()  # Fall back to default
-            ```
-        """
-        backend_name = name or self._default_backend
-        if not backend_name or backend_name not in self._backends:
-            raise BackendNotFoundError(backend_name or "default")
-        return self._backends[backend_name]
-
-    def set_default_backend(self, name: str) -> None:
-        """Set the default backend for the provider.
-
-        Changes the default backend to the specified registered backend.
-        The default backend is used when no specific backend is requested.
-
-        Args:
-            name: The name of the backend to set as default.
-
-        Raises:
-            BackendNotFoundError: If the requested backend is not found.
-
-        Example:
-            ```python
-            # Switch to backup backend as default
-            provider.set_default_backend("redis-backup")
-
-            # Now all default operations use the backup backend
-            backend = provider.get_backend()  # Returns redis-backup
-            ```
-        """
-        if name not in self._backends:
+    def _raise_not_found(self, name: str | None, *, for_default: bool = False) -> NoReturn:
+        if for_default:
             raise BackendNotFoundError(name)
-        self._default_backend = name
-
-    async def ping_all(self) -> dict[str, bool]:
-        """Ping all registered backends to check their availability.
-
-        Performs health checks on all registered backends to determine their
-        current availability status. This is useful for monitoring, alerting,
-        and automatic failover decisions.
-
-        Returns:
-            A dictionary mapping backend names to their availability status.
-            True indicates the backend is available, False indicates it's not.
-
-        Example:
-            ```python
-            # Check all backend health
-            health_status = await provider.ping_all()
-
-            # Log unhealthy backends
-            for backend_name, is_healthy in health_status.items():
-                if not is_healthy:
-                    logger.warning(f"Backend {backend_name} is unhealthy")
-
-            # Find healthy backends
-            healthy_backends = [name for name, status in health_status.items() if status]
-            ```
-        """
-        results = {}
-        for name, backend in self._backends.items():
-            results[name] = await backend.ping()
-        return results
-
-    def list_backends(self) -> dict[str, type[RateLimiterBackend]]:
-        """List all registered backends with their types.
-
-        Returns information about all registered backends, including their
-        implementation types. Useful for debugging, monitoring, and
-        administrative interfaces.
-
-        Returns:
-            A dictionary mapping backend names to their implementation types.
-
-        Example:
-            ```python
-            # List all backends
-            backends = provider.list_backends()
-            for name, backend_type in backends.items():
-                print(f"Backend: {name}, Type: {backend_type.__name__}")
-
-            # Filter for Redis backends
-            redis_backends = {
-                name: backend_type for name, backend_type in backends.items()
-                if "Redis" in backend_type.__name__
-            }
-            ```
-        """
-        return {name: type(backend) for name, backend in self._backends.items()}
-
-    @property
-    def default_backend_name(self) -> str | None:
-        """Get the name of the default backend.
-
-        Returns:
-            The name of the default backend, or None if no default backend is set.
-
-        Example:
-            ```python
-            # Check current default backend
-            default_name = provider.default_backend_name
-            if default_name:
-                print(f"Default backend: {default_name}")
-            else:
-                print("No default backend configured")
-            ```
-        """
-        return self._default_backend
+        raise BackendNotFoundError(name or "default")
 
 
 rate_limiter_provider = RateLimiterProvider()

--- a/backend/tests/unit/infrastructure/backends/test_redis_pool.py
+++ b/backend/tests/unit/infrastructure/backends/test_redis_pool.py
@@ -1,0 +1,67 @@
+"""Tests for the shared Redis connection pool registry."""
+
+import pytest
+
+from src.infrastructure.backends.redis_pool import close_redis_pools, get_redis_pool
+from src.infrastructure.backends.settings import RedisSettings
+from src.infrastructure.cache.backends.redis import RedisBackend as CacheRedisBackend
+from src.infrastructure.rate_limit.backends.redis import RedisBackend as RateLimiterRedisBackend
+
+
+@pytest.fixture(autouse=True)
+async def clean_pools():
+    yield
+    await close_redis_pools()
+
+
+def test_same_settings_share_one_pool():
+    """Cache and rate limiter on the same server share a single pool."""
+    settings = RedisSettings(host="localhost", port=6379, db=0)
+    cache_backend = CacheRedisBackend(settings=settings)
+    rate_limit_backend = RateLimiterRedisBackend(settings=RedisSettings(host="localhost", port=6379, db=0))
+
+    assert cache_backend.client.connection_pool is rate_limit_backend.client.connection_pool
+    assert cache_backend.client.connection_pool is get_redis_pool(settings)
+
+
+def test_different_settings_get_different_pools():
+    """Differing connection parameters must not share a pool."""
+    pool_a = get_redis_pool(RedisSettings(host="localhost", port=6379, db=0))
+    pool_b = get_redis_pool(RedisSettings(host="localhost", port=6379, db=1))
+    pool_c = get_redis_pool(RedisSettings(host="otherhost", port=6379, db=0))
+
+    assert pool_a is not pool_b
+    assert pool_a is not pool_c
+
+
+@pytest.mark.asyncio
+async def test_closing_one_client_does_not_tear_down_shared_pool():
+    """Clients do not own the shared pool: aclose() leaves it usable."""
+    settings = RedisSettings(host="localhost", port=6379, db=0)
+    cache_backend = CacheRedisBackend(settings=settings)
+    rate_limit_backend = RateLimiterRedisBackend(settings=settings)
+    pool = get_redis_pool(settings)
+
+    assert cache_backend.client.auto_close_connection_pool is False
+    assert rate_limit_backend.client.auto_close_connection_pool is False
+
+    await cache_backend.client.aclose()
+
+    assert rate_limit_backend.client.connection_pool is pool
+    assert get_redis_pool(settings) is pool
+
+
+@pytest.mark.asyncio
+async def test_close_redis_pools_disconnects_and_clears():
+    """Central shutdown disconnects pools and empties the registry."""
+    settings = RedisSettings(host="localhost", port=6379, db=0)
+    pool = get_redis_pool(settings)
+
+    await close_redis_pools()
+
+    assert get_redis_pool(settings) is not pool
+
+
+@pytest.mark.asyncio
+async def test_close_redis_pools_without_pools_is_noop():
+    await close_redis_pools()

--- a/backend/tests/unit/infrastructure/rate_limit/backends/test_redis.py
+++ b/backend/tests/unit/infrastructure/rate_limit/backends/test_redis.py
@@ -96,6 +96,16 @@ async def test_get_count(redis_backend):
 
 
 @pytest.mark.asyncio
+async def test_get_count_decodes_bytes(redis_backend):
+    """Shared pools run with decode_responses=False, so get_count must decode bytes."""
+    backend, client_mock, _ = redis_backend
+
+    client_mock.get.return_value = b"7"
+    count = await backend.get_count("test:123")
+    assert count == 7
+
+
+@pytest.mark.asyncio
 async def test_reset(redis_backend):
     """Test resetting the counter for a key."""
     backend, client_mock, _ = redis_backend

--- a/docs/user-guide/configuration/settings-classes.md
+++ b/docs/user-guide/configuration/settings-classes.md
@@ -217,7 +217,7 @@ class StorageSettings(BaseSettings):
     STORAGE_BACKEND: str = config("STORAGE_BACKEND", default=StorageBackend.LOCAL.value)
 ```
 
-The boilerplate already does this for `CacheBackend`, `LogFormat`, `LogLevel`, `SessionBackend`, `TaskiqBrokerType`, and `EnvironmentOption`.
+The boilerplate already does this for `CacheBackendType`, `LogFormat`, `LogLevel`, `SessionBackend`, `TaskiqBrokerType`, and `EnvironmentOption`.
 
 ## Removing Built-in Groups
 


### PR DESCRIPTION
The cache and rate-limit infrastructure packages were near-verbatim copies at the connection layer: RedisSettings and MemcachedSettings were each defined twice, optional-dependency detection ran in four places with inconsistent module names, and both subsystems opened separate Redis connection pools to the same server.

This PR adds a small infrastructure/backends package that holds the connection settings models (field names unchanged, so env parsing is identical), the dependency-detection flags, a generic BackendProvider that both provider modules now subclass, and a ConnectionPool registry keyed by connection parameters so identical configs share one pool. The cache and rate-limit ABCs and their operation logic are untouched.

Lifecycle: pools are disconnected once, centrally, during lifespan shutdown; per redis-py semantics, closing a client built on a shared pool only closes the client, so one subsystem shutting down cannot break the other. Also included: close_cache and close_rate_limiter no longer raise when the backend was never registered, and the CacheBackend enum is renamed to CacheBackendType to resolve the collision with the CacheBackend ABC.

Depends on #281 (gated-docs, both touch app_factory.py) and #286 (rate-limit-backends, both touch the rate-limit backends); merge those first.

Written by Kimi, Authored by @emiliano-go

